### PR TITLE
Patch 2 - Feature: add PHP version to the command links and parked outputs and new command php:which

### DIFF
--- a/cli/Valet/Acrylic.php
+++ b/cli/Valet/Acrylic.php
@@ -4,216 +4,216 @@ namespace Valet;
 
 class Acrylic
 {
-    /**
-     * @var CommandLine
-     */
-    protected $cli;
+	/**
+	 * @var CommandLine
+	 */
+	protected $cli;
 
-    /**
-     * @var Filesystem
-     */
-    protected $files;
+	/**
+	 * @var Filesystem
+	 */
+	protected $files;
 
-    /**
-     * Create a new Acrylic instance.
-     *
-     * @param  CommandLine  $cli
-     * @param  Filesystem  $files
-     * @return void
-     */
-    public function __construct(CommandLine $cli, Filesystem $files)
-    {
-        $this->cli = $cli;
-        $this->files = $files;
-    }
+	/**
+	 * Create a new Acrylic instance.
+	 *
+	 * @param  CommandLine  $cli
+	 * @param  Filesystem  $files
+	 * @return void
+	 */
+	public function __construct(CommandLine $cli, Filesystem $files)
+	{
+		$this->cli = $cli;
+		$this->files = $files;
+	}
 
-    /**
-     * Install Acrylic DNS.
-     *
-     * @param  string  $tld
-     * @return void
-     */
-    public function install(string $tld = 'test')
-    {
-        info('Installing Acrylic DNS...');
+	/**
+	 * Install Acrylic DNS.
+	 *
+	 * @param  string  $tld
+	 * @return void
+	 */
+	public function install(string $tld = 'test')
+	{
+		info('Installing Acrylic DNS...');
 
-        $this->createHostsFile($tld);
-        $this->installService();
-    }
+		$this->createHostsFile($tld);
+		$this->installService();
+	}
 
-    /**
-     * Create the AcrylicHosts file.
-     *
-     * @param  string  $tld
-     * @return void
-     */
-    protected function createHostsFile(string $tld)
-    {
-        $contents = $this->files->get(__DIR__.'/../stubs/AcrylicHosts.txt');
+	/**
+	 * Create the AcrylicHosts file.
+	 *
+	 * @param  string  $tld
+	 * @return void
+	 */
+	protected function createHostsFile(string $tld)
+	{
+		$contents = $this->files->get(__DIR__.'/../stubs/AcrylicHosts.txt');
 
-        $this->files->put(
-            $this->path('AcrylicHosts.txt'),
-            str_replace(['VALET_TLD', 'VALET_HOME_PATH'], [$tld, Valet::homePath()], $contents)
-        );
+		$this->files->put(
+			$this->path('AcrylicHosts.txt'),
+			str_replace(['VALET_TLD', 'VALET_HOME_PATH'], [$tld, Valet::homePath()], $contents)
+		);
 
-        if (! $this->files->exists($configPath = Valet::homePath('AcrylicHosts.txt'))) {
-            $this->files->putAsUser($configPath, PHP_EOL);
-        }
-    }
+		if (! $this->files->exists($configPath = Valet::homePath('AcrylicHosts.txt'))) {
+			$this->files->putAsUser($configPath, PHP_EOL);
+		}
+	}
 
-    /**
-     * Install the Acrylic DNS service.
-     *
-     * @return void
-     */
-    protected function installService()
-    {
-        $this->uninstall();
+	/**
+	 * Install the Acrylic DNS service.
+	 *
+	 * @return void
+	 */
+	protected function installService()
+	{
+		$this->uninstall();
 
-        $this->configureNetworkDNS();
+		$this->configureNetworkDNS();
 
-        $this->cli->runOrExit('cmd /C "'.$this->path('AcrylicUI.exe').'" InstallAcrylicService', function ($code, $output) {
-            error("Failed to install Acrylic DNS: $output");
-        });
+		$this->cli->runOrExit('cmd /C "'.$this->path('AcrylicUI.exe').'" InstallAcrylicService', function ($code, $output) {
+			error("Failed to install Acrylic DNS: $output");
+		});
 
-        $this->flushdns();
-    }
+		$this->flushdns();
+	}
 
-    /**
-     * Configure the Network DNS.
-     *
-     * @return void
-     */
-    protected function configureNetworkDNS()
-    {
-        $this->cli->powershell(implode(';', [
-            '(Get-NetIPAddress -AddressFamily IPv4).InterfaceIndex | ForEach-Object {Set-DnsClientServerAddress -InterfaceIndex $_ -ServerAddresses (\"127.0.0.1\", \"8.8.8.8\")}',
-            '(Get-NetIPAddress -AddressFamily IPv6).InterfaceIndex | ForEach-Object {Set-DnsClientServerAddress -InterfaceIndex $_ -ServerAddresses (\"::1\", \"2001:4860:4860::8888\")}',
-        ]));
-    }
+	/**
+	 * Configure the Network DNS.
+	 *
+	 * @return void
+	 */
+	protected function configureNetworkDNS()
+	{
+		$this->cli->powershell(implode(';', [
+			'(Get-NetIPAddress -AddressFamily IPv4).InterfaceIndex | ForEach-Object {Set-DnsClientServerAddress -InterfaceIndex $_ -ServerAddresses (\"127.0.0.1\", \"8.8.8.8\")}',
+			'(Get-NetIPAddress -AddressFamily IPv6).InterfaceIndex | ForEach-Object {Set-DnsClientServerAddress -InterfaceIndex $_ -ServerAddresses (\"::1\", \"2001:4860:4860::8888\")}',
+		]));
+	}
 
-    /**
-     * Update the tld used by Acrylic DNS.
-     *
-     * @param  string  $tld
-     * @return void
-     */
-    public function updateTld(string $tld)
-    {
-        $this->stop();
+	/**
+	 * Update the tld used by Acrylic DNS.
+	 *
+	 * @param  string  $tld
+	 * @return void
+	 */
+	public function updateTld(string $tld)
+	{
+		$this->stop();
 
-        $this->createHostsFile($tld);
+		$this->createHostsFile($tld);
 
-        $this->restart();
-    }
+		$this->restart();
+	}
 
-    /**
-     * Uninstall the Acrylic DNS service.
-     *
-     * @return void
-     */
-    public function uninstall()
-    {
-        if (! $this->installed()) {
-            return;
-        }
+	/**
+	 * Uninstall the Acrylic DNS service.
+	 *
+	 * @return void
+	 */
+	public function uninstall()
+	{
+		if (! $this->installed()) {
+			return;
+		}
 
-        $this->stop();
+		$this->stop();
 
-        $this->cli->run('cmd /C "'.$this->path('AcrylicUI.exe').'" UninstallAcrylicService', function ($code, $output) {
-            warning("Failed to uninstall Acrylic DNS: $output");
-        });
+		$this->cli->run('cmd /C "'.$this->path('AcrylicUI.exe').'" UninstallAcrylicService', function ($code, $output) {
+			warning("Failed to uninstall Acrylic DNS: $output");
+		});
 
-        $this->removeNetworkDNS();
+		$this->removeNetworkDNS();
 
-        $this->flushdns();
-    }
+		$this->flushdns();
+	}
 
-    /**
-     * Determine if the Acrylic DNS is installed.
-     *
-     * @return bool
-     */
-    protected function installed(): bool
-    {
-        return $this->cli->powershell('Get-Service -Name "AcrylicDNSProxySvc"')->isSuccessful();
-    }
+	/**
+	 * Determine if the Acrylic DNS is installed.
+	 *
+	 * @return bool
+	 */
+	protected function installed(): bool
+	{
+		return $this->cli->powershell('Get-Service -Name "AcrylicDNSProxySvc"')->isSuccessful();
+	}
 
-    /**
-     * Remove the Network DNS.
-     *
-     * @return void
-     */
-    protected function removeNetworkDNS()
-    {
-        $this->cli->powershell(implode(';', [
-            '(Get-NetIPAddress -AddressFamily IPv4).InterfaceIndex | ForEach-Object {Set-DnsClientServerAddress -InterfaceIndex $_ -ResetServerAddresses}',
-            '(Get-NetIPAddress -AddressFamily IPv6).InterfaceIndex | ForEach-Object {Set-DnsClientServerAddress -InterfaceIndex $_ -ResetServerAddresses}',
-        ]));
-    }
+	/**
+	 * Remove the Network DNS.
+	 *
+	 * @return void
+	 */
+	protected function removeNetworkDNS()
+	{
+		$this->cli->powershell(implode(';', [
+			'(Get-NetIPAddress -AddressFamily IPv4).InterfaceIndex | ForEach-Object {Set-DnsClientServerAddress -InterfaceIndex $_ -ResetServerAddresses}',
+			'(Get-NetIPAddress -AddressFamily IPv6).InterfaceIndex | ForEach-Object {Set-DnsClientServerAddress -InterfaceIndex $_ -ResetServerAddresses}',
+		]));
+	}
 
-    /**
-     * Start the Acrylic DNS service.
-     *
-     * @return void
-     */
-    public function start()
-    {
-        $this->cli->runOrExit('cmd /C "'.$this->path('AcrylicUI.exe').'" StartAcrylicService', function ($code, $output) {
-            error("Failed to start Acrylic DNS: $output");
-        });
+	/**
+	 * Start the Acrylic DNS service.
+	 *
+	 * @return void
+	 */
+	public function start()
+	{
+		$this->cli->runOrExit('cmd /C "'.$this->path('AcrylicUI.exe').'" StartAcrylicService', function ($code, $output) {
+			error("Failed to start Acrylic DNS: $output");
+		});
 
-        $this->flushdns();
-    }
+		$this->flushdns();
+	}
 
-    /**
-     * Stop the Acrylic DNS service.
-     *
-     * @return void
-     */
-    public function stop()
-    {
-        $this->cli->run('cmd /C "'.$this->path('AcrylicUI.exe').'" StopAcrylicService', function ($code, $output) {
-            warning("Failed to stop Acrylic DNS: $output");
-        });
+	/**
+	 * Stop the Acrylic DNS service.
+	 *
+	 * @return void
+	 */
+	public function stop()
+	{
+		$this->cli->run('cmd /C "'.$this->path('AcrylicUI.exe').'" StopAcrylicService', function ($code, $output) {
+			warning("Failed to stop Acrylic DNS: $output");
+		});
 
-        $this->flushdns();
-    }
+		$this->flushdns();
+	}
 
-    /**
-     * Restart the Acrylic DNS service.
-     *
-     * @return void
-     */
-    public function restart()
-    {
-        $this->cli->run('cmd /C "'.$this->path('AcrylicUI.exe').'" RestartAcrylicService', function ($code, $output) {
-            warning("Failed to restart Acrylic DNS: $output");
-        });
+	/**
+	 * Restart the Acrylic DNS service.
+	 *
+	 * @return void
+	 */
+	public function restart()
+	{
+		$this->cli->run('cmd /C "'.$this->path('AcrylicUI.exe').'" RestartAcrylicService', function ($code, $output) {
+			warning("Failed to restart Acrylic DNS: $output");
+		});
 
-        $this->flushdns();
-    }
+		$this->flushdns();
+	}
 
-    /**
-     * Flush Windows DNS.
-     *
-     * @return void
-     */
-    public function flushdns()
-    {
-        $this->cli->run('cmd "/C ipconfig /flushdns"');
-    }
+	/**
+	 * Flush Windows DNS.
+	 *
+	 * @return void
+	 */
+	public function flushdns()
+	{
+		$this->cli->run('cmd "/C ipconfig /flushdns"');
+	}
 
-    /**
-     * Get the Acrylic path.
-     *
-     * @param  string  $path
-     * @return string
-     */
-    public function path(string $path = ''): string
-    {
-        $basePath = str_replace(DIRECTORY_SEPARATOR, '/', realpath(__DIR__.'/../../bin/Acrylic'));
+	/**
+	 * Get the Acrylic path.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	public function path(string $path = ''): string
+	{
+		$basePath = str_replace(DIRECTORY_SEPARATOR, '/', realpath(__DIR__.'/../../bin/Acrylic'));
 
-        return $basePath.($path ? DIRECTORY_SEPARATOR.$path : $path);
-    }
+		return $basePath.($path ? DIRECTORY_SEPARATOR.$path : $path);
+	}
 }

--- a/cli/Valet/CommandLine.php
+++ b/cli/Valet/CommandLine.php
@@ -6,132 +6,132 @@ use Symfony\Component\Process\Process;
 
 class CommandLine
 {
-    /**
-     * Simple global function to run commands.
-     *
-     * @param  string  $command
-     * @return void
-     */
-    public function quietly($command)
-    {
-        $this->runCommand($command.' > /dev/null 2>&1');
-    }
+	/**
+	 * Simple global function to run commands.
+	 *
+	 * @param  string  $command
+	 * @return void
+	 */
+	public function quietly($command)
+	{
+		$this->runCommand($command.' > /dev/null 2>&1');
+	}
 
-    /**
-     * Simple global function to run commands.
-     *
-     * @param  string  $command
-     * @return void
-     */
-    public function quietlyAsUser($command)
-    {
-        $this->quietly($command.' > /dev/null 2>&1');
-    }
+	/**
+	 * Simple global function to run commands.
+	 *
+	 * @param  string  $command
+	 * @return void
+	 */
+	public function quietlyAsUser($command)
+	{
+		$this->quietly($command.' > /dev/null 2>&1');
+	}
 
-    /**
-     * Pass the command to the command line and display the output.
-     *
-     * @param  string  $command
-     * @return void
-     */
-    public function passthru($command)
-    {
-        passthru($command);
-    }
+	/**
+	 * Pass the command to the command line and display the output.
+	 *
+	 * @param  string  $command
+	 * @return void
+	 */
+	public function passthru($command)
+	{
+		passthru($command);
+	}
 
-    /**
-     * Run the given command as the non-root user.
-     *
-     * @param  string  $command
-     * @param  callable  $onError
-     * @return ProcessOutput
-     */
-    public function run($command, callable $onError = null)
-    {
-        return $this->runCommand($command, $onError);
-    }
+	/**
+	 * Run the given command as the non-root user.
+	 *
+	 * @param  string  $command
+	 * @param  callable  $onError
+	 * @return ProcessOutput
+	 */
+	public function run($command, callable $onError = null)
+	{
+		return $this->runCommand($command, $onError);
+	}
 
-    /**
-     * Run the given command.
-     *
-     * @param  string  $command
-     * @param  callable  $onError
-     * @return ProcessOutput
-     */
-    public function runAsUser($command, callable $onError = null)
-    {
-        return $this->runCommand($command, $onError);
-    }
+	/**
+	 * Run the given command.
+	 *
+	 * @param  string  $command
+	 * @param  callable  $onError
+	 * @return ProcessOutput
+	 */
+	public function runAsUser($command, callable $onError = null)
+	{
+		return $this->runCommand($command, $onError);
+	}
 
-    /**
-     * Run the given command with PowerShell.
-     *
-     * @param  string  $command
-     * @param  callable|null  $onError
-     * @return ProcessOutput
-     */
-    public function powershell(string $command, callable $onError = null)
-    {
-        return $this->runCommand("powershell -command \"$command\"", $onError);
-    }
+	/**
+	 * Run the given command with PowerShell.
+	 *
+	 * @param  string  $command
+	 * @param  callable|null  $onError
+	 * @return ProcessOutput
+	 */
+	public function powershell(string $command, callable $onError = null)
+	{
+		return $this->runCommand("powershell -command \"$command\"", $onError);
+	}
 
-    /**
-     * @deprecated
-     */
-    public function runOrDie($command, callable $onError = null)
-    {
-        return $this->runOrExit($command, $onError);
-    }
+	/**
+	 * @deprecated
+	 */
+	public function runOrDie($command, callable $onError = null)
+	{
+		return $this->runOrExit($command, $onError);
+	}
 
-    /**
-     * Run the given command and exit if fails.
-     *
-     * @param  string  $command
-     * @param  callable  $onError  (int $code, string $output)
-     * @return ProcessOutput
-     */
-    public function runOrExit($command, callable $onError = null)
-    {
-        return $this->run($command, function ($code, $output) use ($onError) {
-            if ($onError) {
-                $onError($code, $output);
-            }
+	/**
+	 * Run the given command and exit if fails.
+	 *
+	 * @param  string  $command
+	 * @param  callable  $onError  (int $code, string $output)
+	 * @return ProcessOutput
+	 */
+	public function runOrExit($command, callable $onError = null)
+	{
+		return $this->run($command, function ($code, $output) use ($onError) {
+			if ($onError) {
+				$onError($code, $output);
+			}
 
-            exit(1);
-        });
-    }
+			exit(1);
+		});
+	}
 
-    /**
-     * Run the given command.
-     *
-     * @param  string  $command
-     * @param  callable  $onError
-     * @return ProcessOutput
-     */
-    public function runCommand($command, callable $onError = null)
-    {
-        $onError = $onError ?: function () {
-        };
+	/**
+	 * Run the given command.
+	 *
+	 * @param  string  $command
+	 * @param  callable  $onError
+	 * @return ProcessOutput
+	 */
+	public function runCommand($command, callable $onError = null)
+	{
+		$onError = $onError ?: function () {
+		};
 
-        // Symfony's 4.x Process component has deprecated passing a command string
-        // to the constructor, but older versions (which Valet's Composer
-        // constraints allow) don't have the fromShellCommandLine method.
-        // For more information, see: https://github.com/laravel/valet/pull/761
-        if (method_exists(Process::class, 'fromShellCommandline')) {
-            $process = Process::fromShellCommandline($command);
-        } else {
-            $process = new Process($command);
-        }
+		// Symfony's 4.x Process component has deprecated passing a command string
+		// to the constructor, but older versions (which Valet's Composer
+		// constraints allow) don't have the fromShellCommandLine method.
+		// For more information, see: https://github.com/laravel/valet/pull/761
+		if (method_exists(Process::class, 'fromShellCommandline')) {
+			$process = Process::fromShellCommandline($command);
+		} else {
+			$process = new Process($command);
+		}
 
-        $processOutput = '';
-        $process->setTimeout(60)->run(function ($type, $line) use (&$processOutput) {
-            $processOutput .= $line;
-        });
+		$processOutput = '';
+		$process->setTimeout(60)->run(function ($type, $line) use (&$processOutput) {
+			$processOutput .= $line;
+		});
 
-        if ($process->getExitCode() !== 0) {
-            $onError($process->getExitCode(), $processOutput);
-        }
+		if ($process->getExitCode() !== 0) {
+			$onError($process->getExitCode(), $processOutput);
+		}
 
-        return new ProcessOutput($process);
-    }
+		return new ProcessOutput($process);
+	}
 }

--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -6,460 +6,460 @@ use Illuminate\Support\Arr;
 
 class Configuration
 {
-    /**
-     * @var Filesystem
-     */
-    protected $files;
+	/**
+	 * @var Filesystem
+	 */
+	protected $files;
 
-    /**
-     * Create a new Valet configuration class instance.
-     *
-     * @param  Filesystem  $filesystem
-     * @return void
-     */
-    public function __construct(Filesystem $files)
-    {
-        $this->files = $files;
-    }
+	/**
+	 * Create a new Valet configuration class instance.
+	 *
+	 * @param  Filesystem  $filesystem
+	 * @return void
+	 */
+	public function __construct(Filesystem $files)
+	{
+		$this->files = $files;
+	}
 
-    /**
-     * Install the Valet configuration file.
-     *
-     * @return void
-     */
-    public function install()
-    {
-        info('Installing Configuration...');
+	/**
+	 * Install the Valet configuration file.
+	 *
+	 * @return void
+	 */
+	public function install()
+	{
+		info('Installing Configuration...');
 
-        $this->createConfigurationDirectory();
-        $this->createDriversDirectory();
-        $this->createSitesDirectory();
-        $this->createExtensionsDirectory();
-        $this->createLogDirectory();
-        $this->createCertificatesDirectory();
-        $this->createServicesDirectory();
-        $this->createXdebugDirectory();
-        $this->writeBaseConfiguration();
+		$this->createConfigurationDirectory();
+		$this->createDriversDirectory();
+		$this->createSitesDirectory();
+		$this->createExtensionsDirectory();
+		$this->createLogDirectory();
+		$this->createCertificatesDirectory();
+		$this->createServicesDirectory();
+		$this->createXdebugDirectory();
+		$this->writeBaseConfiguration();
 
-        $this->files->chown($this->path(), user());
-    }
+		$this->files->chown($this->path(), user());
+	}
 
-    /**
-     * Create the Valet configuration directory.
-     *
-     * @return void
-     */
-    public function createConfigurationDirectory()
-    {
-        $this->files->ensureDirExists(preg_replace('~/valet$~', '', $this->valetHomePath()), user());
+	/**
+	 * Create the Valet configuration directory.
+	 *
+	 * @return void
+	 */
+	public function createConfigurationDirectory()
+	{
+		$this->files->ensureDirExists(preg_replace('~/valet$~', '', $this->valetHomePath()), user());
 
-        $oldPath = $_SERVER['HOME'].'/.valet';
+		$oldPath = $_SERVER['HOME'] . '/.valet';
 
-        if ($this->files->isDir($oldPath)) {
-            rename($oldPath, $this->valetHomePath());
-            $this->prependPath($this->valetHomePath('Sites'));
-        }
+		if ($this->files->isDir($oldPath)) {
+			rename($oldPath, $this->valetHomePath());
+			$this->prependPath($this->valetHomePath('Sites'));
+		}
 
-        $this->files->ensureDirExists($this->valetHomePath(), user());
-    }
+		$this->files->ensureDirExists($this->valetHomePath(), user());
+	}
 
-    /**
-     * Create the Valet drivers directory.
-     *
-     * @return void
-     */
-    public function createDriversDirectory()
-    {
-        $driversPath = $this->valetHomePath('Drivers');
+	/**
+	 * Create the Valet drivers directory.
+	 *
+	 * @return void
+	 */
+	public function createDriversDirectory()
+	{
+		$driversPath = $this->valetHomePath('Drivers');
 
-        if ($this->files->isDir($driversPath)) {
-            return;
-        }
+		if ($this->files->isDir($driversPath)) {
+			return;
+		}
 
-        $this->files->mkdirAsUser($driversPath);
+		$this->files->mkdirAsUser($driversPath);
 
-        $this->files->putAsUser(
-            $driversPath.'/SampleValetDriver.php',
-            $this->files->get(__DIR__.'/../stubs/SampleValetDriver.php')
-        );
-    }
+		$this->files->putAsUser(
+			$driversPath . '/SampleValetDriver.php',
+			$this->files->get(__DIR__ . '/../stubs/SampleValetDriver.php')
+		);
+	}
 
-    /**
-     * Create the Valet sites directory.
-     *
-     * @return void
-     */
-    public function createSitesDirectory()
-    {
-        $this->files->ensureDirExists($this->valetHomePath('Sites'), user());
-    }
+	/**
+	 * Create the Valet sites directory.
+	 *
+	 * @return void
+	 */
+	public function createSitesDirectory()
+	{
+		$this->files->ensureDirExists($this->valetHomePath('Sites'), user());
+	}
 
-    /**
-     * Create the directory for the Valet extensions.
-     *
-     * @return void
-     */
-    public function createExtensionsDirectory()
-    {
-        $this->files->ensureDirExists(Valet::homePath('Extensions'), user());
-    }
+	/**
+	 * Create the directory for the Valet extensions.
+	 *
+	 * @return void
+	 */
+	public function createExtensionsDirectory()
+	{
+		$this->files->ensureDirExists(Valet::homePath('Extensions'), user());
+	}
 
-    /**
-     * Create the directory for logs.
-     *
-     * @return void
-     */
-    public function createLogDirectory()
-    {
-        $this->files->ensureDirExists($path = $this->valetHomePath('Log'), user());
+	/**
+	 * Create the directory for logs.
+	 *
+	 * @return void
+	 */
+	public function createLogDirectory()
+	{
+		$this->files->ensureDirExists($path = $this->valetHomePath('Log'), user());
 
-        $this->files->touch($path.DIRECTORY_SEPARATOR.'nginx-error.log');
-    }
+		$this->files->touch($path . DIRECTORY_SEPARATOR . 'nginx-error.log');
+	}
 
-    /**
-     * Create the directory for SSL certificates.
-     *
-     * @return void
-     */
-    public function createCertificatesDirectory()
-    {
-        $this->files->ensureDirExists($this->valetHomePath('Certificates'), user());
-    }
+	/**
+	 * Create the directory for SSL certificates.
+	 *
+	 * @return void
+	 */
+	public function createCertificatesDirectory()
+	{
+		$this->files->ensureDirExists($this->valetHomePath('Certificates'), user());
+	}
 
-    /**
-     * Create the directory for the Windows services.
-     *
-     * @return void
-     */
-    public function createServicesDirectory()
-    {
-        $this->files->ensureDirExists($this->valetHomePath('Services'), user());
-    }
+	/**
+	 * Create the directory for the Windows services.
+	 *
+	 * @return void
+	 */
+	public function createServicesDirectory()
+	{
+		$this->files->ensureDirExists($this->valetHomePath('Services'), user());
+	}
 
-    /**
-     * Create the directory for the Xdebug profiler.
-     *
-     * @return void
-     */
-    public function createXdebugDirectory()
-    {
-        $this->files->ensureDirExists($this->valetHomePath('Xdebug'), user());
-    }
+	/**
+	 * Create the directory for the Xdebug profiler.
+	 *
+	 * @return void
+	 */
+	public function createXdebugDirectory()
+	{
+		$this->files->ensureDirExists($this->valetHomePath('Xdebug'), user());
+	}
 
-    /**
-     * Write the base, initial configuration for Valet.
-     *
-     * @return void
-     */
-    public function writeBaseConfiguration()
-    {
-        if (! $this->files->exists($this->path())) {
-            $this->write(['tld' => 'test', 'paths' => [], 'php_port' => PhpCgi::PORT, 'php_xdebug_port' => PhpCgiXdebug::PORT]);
-        }
+	/**
+	 * Write the base, initial configuration for Valet.
+	 *
+	 * @return void
+	 */
+	public function writeBaseConfiguration()
+	{
+		if (!$this->files->exists($this->path())) {
+			$this->write(['tld' => 'test', 'paths' => [], 'php_port' => PhpCgi::PORT, 'php_xdebug_port' => PhpCgiXdebug::PORT]);
+		}
 
-        $config = $this->read();
+		$config = $this->read();
 
-        // Migrate old configurations from 'domain' to 'tld'.
-        if (! isset($config['tld'])) {
-            $this->updateKey('tld', ! empty($config['domain']) ? $config['domain'] : 'test');
-        }
+		// Migrate old configurations from 'domain' to 'tld'.
+		if (!isset($config['tld'])) {
+			$this->updateKey('tld', !empty($config['domain']) ? $config['domain'] : 'test');
+		}
 
-        $this->addDefaultPhp();
+		$this->addDefaultPhp();
 
-        // Add php_port if missing.
-        $this->updateKey('php_port', $config['php_port'] ?? PhpCgi::PORT);
-        $this->updateKey('php_xdebug_port', $config['php_xdebug_port'] ?? PhpCgiXdebug::PORT);
-    }
+		// Add php_port if missing.
+		$this->updateKey('php_port', $config['php_port'] ?? PhpCgi::PORT);
+		$this->updateKey('php_xdebug_port', $config['php_xdebug_port'] ?? PhpCgiXdebug::PORT);
+	}
 
-    /**
-     * Forcefully delete the Valet home configuration directory and contents.
-     *
-     * @return void
-     */
-    public function uninstall()
-    {
-        $this->files->unlink($this->valetHomePath());
-    }
+	/**
+	 * Forcefully delete the Valet home configuration directory and contents.
+	 *
+	 * @return void
+	 */
+	public function uninstall()
+	{
+		$this->files->unlink($this->valetHomePath());
+	}
 
-    /**
-     * Add the given php path to the configuration.
-     *
-     * @param  string  $path
-     * @param  bool  $prepend
-     * @return void
-     */
-    public function addDefaultPhp()
-    {
-        $phpPath = $phpPath ?? \PhpCgi::findDefaultPhpPath();
+	/**
+	 * Add the given php path to the configuration.
+	 *
+	 * @param  string  $path
+	 * @param  bool  $prepend
+	 * @return void
+	 */
+	public function addDefaultPhp()
+	{
+		$phpPath = $phpPath ?? \PhpCgi::findDefaultPhpPath();
 
-        $this->addPhp($phpPath);
+		$this->addPhp($phpPath);
 
-        $php = $this->getPhp($phpPath);
+		$php = $this->getPhp($phpPath);
 
-        $this->updateKey('default_php', $php['version']);
-    }
+		$this->updateKey('default_php', $php['version']);
+	}
 
-    /**
-     * Get the php configuration by path.
-     *
-     * @param  string  $phpPath
-     * @return mixed
-     */
-    public function getPhp($phpPath)
-    {
-        $phpPath = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $phpPath);
+	/**
+	 * Get the php configuration by path.
+	 *
+	 * @param  string  $phpPath
+	 * @return mixed
+	 */
+	public function getPhp($phpPath)
+	{
+		$phpPath = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $phpPath);
 
-        $config = $this->read();
+		$config = $this->read();
 
-        return collect($config['php'])->filter(function ($item) use ($phpPath) {
-            return $phpPath === $item['path'];
-        })->first();
-    }
+		return collect($config['php'])->filter(function ($item) use ($phpPath) {
+			return $phpPath === $item['path'];
+		})->first();
+	}
 
-    /**
-     * Get the php configuration by version.
-     *
-     * @param  string  $phpVersion
-     * @return mixed
-     */
-    public function getPhpByVersion($phpVersion)
-    {
-        $phpVersion = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $phpVersion);
+	/**
+	 * Get the php configuration by version.
+	 *
+	 * @param  string  $phpVersion
+	 * @return mixed
+	 */
+	public function getPhpByVersion($phpVersion)
+	{
+		$phpVersion = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $phpVersion);
 
-        $config = $this->read();
+		$config = $this->read();
 
-        return collect($config['php'])->filter(function ($item) use ($phpVersion) {
-            return $phpVersion === $item['version'];
-        })->first();
-    }
+		return collect($config['php'])->filter(function ($item) use ($phpVersion) {
+			return $phpVersion === $item['version'] || $phpVersion === $item['alias'];
+		})->first();
+	}
 
-    /**
-     * Add the given php path to the configuration.
-     *
-     * @param  string  $phpPath
-     * @return mixed
-     */
-    public function addPhp($phpPath)
-    {
-        $phpPath = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $phpPath);
-//        print_r($phpPath);
+	/**
+	 * Add the given php path to the configuration.
+	 *
+	 * @param  string  $phpPath
+	 * @return mixed
+	 */
+	public function addPhp($phpPath)
+	{
+		$phpPath = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $phpPath);
+		//        print_r($phpPath);
 //        exit;
 
-        $phpVersion = \PhpCgi::findPhpVersion($phpPath);
+		$phpVersion = \PhpCgi::findPhpVersion($phpPath);
 
-        $config = $this->read();
-        $config['php'] = $config['php'] ?? [];
+		$config = $this->read();
+		$config['php'] = $config['php'] ?? [];
 
-        $existingPaths = collect($config['php'])->pluck('path')->toArray();
-        $existingPorts = collect($config['php'])->pluck('port')->toArray();
+		$existingPaths = collect($config['php'])->pluck('path')->toArray();
+		$existingPorts = collect($config['php'])->pluck('port')->toArray();
 
-        // don't want to overwrite existing config as there might be phpcgi service running for it
-        // forcing user to run uninstall to stop services and remove entry
-        if (in_array($phpPath, $existingPaths)) {
-            warning("PHP path {$phpPath} already added to valet");
+		// don't want to overwrite existing config as there might be phpcgi service running for it
+		// forcing user to run uninstall to stop services and remove entry
+		if (in_array($phpPath, $existingPaths)) {
+			warning("PHP path {$phpPath} already added to valet");
 
-            return null;
-        }
+			return null;
+		}
 
-        if (isset($config['php'][$phpVersion])) {
-            warning("PHP version {$phpVersion} already added to valet from this path {$phpPath}");
+		if (isset($config['php'][$phpVersion])) {
+			warning("PHP version {$phpVersion} already added to valet from this path {$phpPath}");
 
-            return null;
-        }
+			return null;
+		}
 
-        if ($existingPorts) {
-            rsort($existingPorts);
-        }
+		if ($existingPorts) {
+			rsort($existingPorts);
+		}
 
-        $phpPort = count($existingPorts) ? $existingPorts[0] + 1 : PhpCgi::PORT;
-        $phpXdebugPort = $phpPort + 100;
+		$phpPort = count($existingPorts) ? $existingPorts[0] + 1 : PhpCgi::PORT;
+		$phpXdebugPort = $phpPort + 100;
 
-        $config['php'][$phpVersion] = [
-            'version' => $phpVersion,
-            'path' => $phpPath,
-            'port' => $phpPort,
-            'xdebug_port' => $phpXdebugPort,
-        ];
+		$config['php'][$phpVersion] = [
+			'version' => $phpVersion,
+			'path' => $phpPath,
+			'port' => $phpPort,
+			'xdebug_port' => $phpXdebugPort,
+		];
 
-        $this->write($config);
+		$this->write($config);
 
-        return $config['php'][$phpVersion];
-    }
+		return $config['php'][$phpVersion];
+	}
 
-    /**
-     * Remove the given php path from the configuration.
-     *
-     * @param  string  $phpPath
-     * @return mixed
-     */
-    public function removePhp($phpPath)
-    {
-        $phpPath = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $phpPath);
+	/**
+	 * Remove the given php path from the configuration.
+	 *
+	 * @param  string  $phpPath
+	 * @return mixed
+	 */
+	public function removePhp($phpPath)
+	{
+		$phpPath = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $phpPath);
 
-        $config = $this->read();
-        $config['php'] = $config['php'] ?? [];
+		$config = $this->read();
+		$config['php'] = $config['php'] ?? [];
 
-        $existingPaths = collect($config['php'])->pluck('path')->toArray();
-        $existingVersions = collect($config['php'])->pluck('port')->toArray();
+		$existingPaths = collect($config['php'])->pluck('path')->toArray();
+		$existingVersions = collect($config['php'])->pluck('port')->toArray();
 
-        if (! in_array($phpPath, $existingPaths)) {
-            warning("PHP path {$phpPath} not found in valet");
+		if (!in_array($phpPath, $existingPaths)) {
+			warning("PHP path {$phpPath} not found in valet");
 
-            return null;
-        }
+			return null;
+		}
 
-        $php = collect($config['php'])->filter(function ($item) use ($phpPath) {
-            return $phpPath === $item['path'];
-        })->first();
+		$php = collect($config['php'])->filter(function ($item) use ($phpPath) {
+			return $phpPath === $item['path'];
+		})->first();
 
-        if ($php['version'] === $config['default_php']) {
-            error("Default PHP {$php['version']} cannot be removed");
+		if ($php['version'] === $config['default_php']) {
+			error("Default PHP {$php['version']} cannot be removed");
 
-            return null;
-        }
+			return null;
+		}
 
-        unset($config['php'][$php['version']]);
+		unset($config['php'][$php['version']]);
 
-        $this->write($config);
+		$this->write($config);
 
-        return $php;
-    }
+		return $php;
+	}
 
-    /**
-     * Add the given path to the configuration.
-     *
-     * @param  string  $path
-     * @param  bool  $prepend
-     * @return void
-     */
-    public function addPath(string $path, bool $prepend = false)
-    {
-        $this->write(tap($this->read(), function (&$config) use ($path, $prepend) {
-            $method = $prepend ? 'prepend' : 'push';
+	/**
+	 * Add the given path to the configuration.
+	 *
+	 * @param  string  $path
+	 * @param  bool  $prepend
+	 * @return void
+	 */
+	public function addPath(string $path, bool $prepend = false)
+	{
+		$this->write(tap($this->read(), function (&$config) use ($path, $prepend) {
+			$method = $prepend ? 'prepend' : 'push';
 
-            $config['paths'] = collect($config['paths'])->{$method}($path)->unique()->all();
-        }));
-    }
+			$config['paths'] = collect($config['paths'])->{$method}($path)->unique()->all();
+		}));
+	}
 
-    /**
-     * Prepend the given path to the configuration.
-     *
-     * @param  string  $path
-     * @return void
-     */
-    public function prependPath(string $path)
-    {
-        $this->addPath($path, true);
-    }
+	/**
+	 * Prepend the given path to the configuration.
+	 *
+	 * @param  string  $path
+	 * @return void
+	 */
+	public function prependPath(string $path)
+	{
+		$this->addPath($path, true);
+	}
 
-    /**
-     * Remove the given path from the configuration.
-     *
-     * @param  string  $path
-     * @return void
-     */
-    public function removePath(string $path)
-    {
-        if ($path == $this->valetHomePath('Sites')) {
-            info("Cannot remove this directory because this is where Valet stores its site definitions.\nRun [valet paths] for a list of parked paths.");
-            exit();
-        }
+	/**
+	 * Remove the given path from the configuration.
+	 *
+	 * @param  string  $path
+	 * @return void
+	 */
+	public function removePath(string $path)
+	{
+		if ($path == $this->valetHomePath('Sites')) {
+			info("Cannot remove this directory because this is where Valet stores its site definitions.\nRun [valet paths] for a list of parked paths.");
+			exit();
+		}
 
-        $this->write(tap($this->read(), function (&$config) use ($path) {
-            $config['paths'] = collect($config['paths'])->reject(function ($value) use ($path) {
-                return $value === $path;
-            })->values()->all();
-        }));
-    }
+		$this->write(tap($this->read(), function (&$config) use ($path) {
+			$config['paths'] = collect($config['paths'])->reject(function ($value) use ($path) {
+				return $value === $path;
+			})->values()->all();
+		}));
+	}
 
-    /**
-     * Prune all non-existent paths from the configuration.
-     *
-     * @return void
-     */
-    public function prune()
-    {
-        if (! $this->files->exists($this->path())) {
-            return;
-        }
+	/**
+	 * Prune all non-existent paths from the configuration.
+	 *
+	 * @return void
+	 */
+	public function prune()
+	{
+		if (!$this->files->exists($this->path())) {
+			return;
+		}
 
-        $this->write(tap($this->read(), function (&$config) {
-            $config['paths'] = collect($config['paths'])->filter(function ($path) {
-                return $this->files->isDir($path);
-            })->values()->all();
-        }));
-    }
+		$this->write(tap($this->read(), function (&$config) {
+			$config['paths'] = collect($config['paths'])->filter(function ($path) {
+				return $this->files->isDir($path);
+			})->values()->all();
+		}));
+	}
 
-    /**
-     * Read the configuration file as JSON.
-     *
-     * @return array
-     */
-    public function read(): array
-    {
-        return json_decode($this->files->get($this->path()), true);
-    }
+	/**
+	 * Read the configuration file as JSON.
+	 *
+	 * @return array
+	 */
+	public function read(): array
+	{
+		return json_decode($this->files->get($this->path()), true);
+	}
 
-    /**
-     * Get an item from the configuration file using "dot" notation.
-     *
-     * @param  string|int|null  $key
-     * @param  mixed  $default
-     * @return mixed
-     */
-    public function get($key, $default = null)
-    {
-        return Arr::get($this->read(), $key, $default);
-    }
+	/**
+	 * Get an item from the configuration file using "dot" notation.
+	 *
+	 * @param  string|int|null  $key
+	 * @param  mixed  $default
+	 * @return mixed
+	 */
+	public function get($key, $default = null)
+	{
+		return Arr::get($this->read(), $key, $default);
+	}
 
-    /**
-     * Update a specific key in the configuration file.
-     *
-     * @param  string  $key
-     * @param  mixed  $value
-     * @return array
-     */
-    public function updateKey(string $key, $value): array
-    {
-        return tap($this->read(), function (&$config) use ($key, $value) {
-            $config[$key] = $value;
+	/**
+	 * Update a specific key in the configuration file.
+	 *
+	 * @param  string  $key
+	 * @param  mixed  $value
+	 * @return array
+	 */
+	public function updateKey(string $key, $value): array
+	{
+		return tap($this->read(), function (&$config) use ($key, $value) {
+			$config[$key] = $value;
 
-            $this->write($config);
-        });
-    }
+			$this->write($config);
+		});
+	}
 
-    /**
-     * Write the given configuration to disk.
-     *
-     * @param  array  $config
-     * @return void
-     */
-    public function write(array $config)
-    {
-        $this->files->putAsUser($this->path(), json_encode(
-            $config,
-            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
-        ).PHP_EOL);
-    }
+	/**
+	 * Write the given configuration to disk.
+	 *
+	 * @param  array  $config
+	 * @return void
+	 */
+	public function write(array $config)
+	{
+		$this->files->putAsUser($this->path(), json_encode(
+			$config,
+			JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+		) . PHP_EOL);
+	}
 
-    /**
-     * Get the configuration file path.
-     *
-     * @return string
-     */
-    public function path(): string
-    {
-        return $this->valetHomePath('config.json');
-    }
+	/**
+	 * Get the configuration file path.
+	 *
+	 * @return string
+	 */
+	public function path(): string
+	{
+		return $this->valetHomePath('config.json');
+	}
 
-    /**
-     * Get the Valet home path.
-     *
-     * @param  string  $path
-     * @return string
-     */
-    protected function valetHomePath(string $path = ''): string
-    {
-        return Valet::homePath($path);
-    }
+	/**
+	 * Get the Valet home path.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	protected function valetHomePath(string $path = ''): string
+	{
+		return Valet::homePath($path);
+	}
 }

--- a/cli/Valet/Diagnose.php
+++ b/cli/Valet/Diagnose.php
@@ -7,163 +7,163 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 class Diagnose
 {
-    /**
-     * @var array
-     */
-    protected $commands = [
-        'systeminfo | findstr /B /C:"OS Name" /C:"OS Version"',
-        'valet --version',
-        'cat ~/.config/valet/config.json',
-        // 'cat ~/.composer/composer.json',
-        'composer global diagnose',
-        'composer global outdated',
-        // 'ls -al /etc/sudoers.d/',
-        // 'brew update > /dev/null 2>&1',
-        // 'brew config',
-        // 'brew services list',
-        // 'brew list --formula --versions | grep -E "(php|nginx|dnsmasq|mariadb|mysql|mailhog|openssl)(@\d\..*)?\s"',
-        // 'brew outdated',
-        // 'brew tap',
-        'php -v',
-        'which -a php',
-        'php --ini',
-        // __DIR__.'/../../bin/nginx/nginx.exe -v',
-        // 'curl --version',
-        'php --ri curl',
-        // __DIR__.'/../../bin/ngrok.exe version',
-        'ls -al ~/.ngrok2',
-        // 'brew info nginx',
-        // 'brew info php',
-        // 'brew info openssl',
-        // 'openssl version -a',
-        // 'openssl ciphers',
-        // 'sudo nginx -t',
-        // 'which -a php-fpm',
-        // BREW_PREFIX.'/opt/php/sbin/php-fpm -v',
-        // 'sudo '.BREW_PREFIX.'/opt/php/sbin/php-fpm -y '.PHP_SYSCONFDIR.'/php-fpm.conf --test',
-        // 'ls -al ~/Library/LaunchAgents | grep homebrew',
-        // 'ls -al /Library/LaunchAgents | grep homebrew',
-        // 'ls -al /Library/LaunchDaemons | grep homebrew',
-        // 'ls -aln /etc/resolv.conf',
-        // 'cat /etc/resolv.conf',
-    ];
+	/**
+	 * @var array
+	 */
+	protected $commands = [
+		'systeminfo | findstr /B /C:"OS Name" /C:"OS Version"',
+		'valet --version',
+		'cat ~/.config/valet/config.json',
+		// 'cat ~/.composer/composer.json',
+		'composer global diagnose',
+		'composer global outdated',
+		// 'ls -al /etc/sudoers.d/',
+		// 'brew update > /dev/null 2>&1',
+		// 'brew config',
+		// 'brew services list',
+		// 'brew list --formula --versions | grep -E "(php|nginx|dnsmasq|mariadb|mysql|mailhog|openssl)(@\d\..*)?\s"',
+		// 'brew outdated',
+		// 'brew tap',
+		'php -v',
+		'which -a php',
+		'php --ini',
+		// __DIR__.'/../../bin/nginx/nginx.exe -v',
+		// 'curl --version',
+		'php --ri curl',
+		// __DIR__.'/../../bin/ngrok.exe version',
+		'ls -al ~/.ngrok2',
+		// 'brew info nginx',
+		// 'brew info php',
+		// 'brew info openssl',
+		// 'openssl version -a',
+		// 'openssl ciphers',
+		// 'sudo nginx -t',
+		// 'which -a php-fpm',
+		// BREW_PREFIX.'/opt/php/sbin/php-fpm -v',
+		// 'sudo '.BREW_PREFIX.'/opt/php/sbin/php-fpm -y '.PHP_SYSCONFDIR.'/php-fpm.conf --test',
+		// 'ls -al ~/Library/LaunchAgents | grep homebrew',
+		// 'ls -al /Library/LaunchAgents | grep homebrew',
+		// 'ls -al /Library/LaunchDaemons | grep homebrew',
+		// 'ls -aln /etc/resolv.conf',
+		// 'cat /etc/resolv.conf',
+	];
 
-    protected $cli;
-    protected $files;
-    protected $print;
-    protected $progressBar;
+	protected $cli;
+	protected $files;
+	protected $print;
+	protected $progressBar;
 
-    /**
-     * Create a new Diagnose instance.
-     *
-     * @param  CommandLine  $cli
-     * @param  Filesystem  $files
-     * @return void
-     */
-    public function __construct(CommandLine $cli, Filesystem $files)
-    {
-        $this->cli = $cli;
-        $this->files = $files;
-    }
+	/**
+	 * Create a new Diagnose instance.
+	 *
+	 * @param  CommandLine  $cli
+	 * @param  Filesystem  $files
+	 * @return void
+	 */
+	public function __construct(CommandLine $cli, Filesystem $files)
+	{
+		$this->cli = $cli;
+		$this->files = $files;
+	}
 
-    /**
-     * Run diagnostics.
-     */
-    public function run($print, $plainText)
-    {
-        $this->print = $print;
+	/**
+	 * Run diagnostics.
+	 */
+	public function run($print, $plainText)
+	{
+		$this->print = $print;
 
-        $this->beforeRun();
+		$this->beforeRun();
 
-        $results = collect($this->commands)->map(function ($command) {
-            $this->beforeCommand($command);
+		$results = collect($this->commands)->map(function ($command) {
+			$this->beforeCommand($command);
 
-            $output = $this->runCommand($command);
+			$output = $this->runCommand($command);
 
-            if ($this->ignoreOutput($command)) {
-                return;
-            }
+			if ($this->ignoreOutput($command)) {
+				return;
+			}
 
-            $this->afterCommand($command, $output);
+			$this->afterCommand($command, $output);
 
-            return compact('command', 'output');
-        })->filter()->values();
+			return compact('command', 'output');
+		})->filter()->values();
 
-        $output = $this->format($results, $plainText);
+		$output = $this->format($results, $plainText);
 
-        if (! $this->print) {
-            output(PHP_EOL.PHP_EOL.$output);
-        }
+		if (! $this->print) {
+			output(PHP_EOL.PHP_EOL.$output);
+		}
 
-        // $this->files->put('valet_diagnostics.txt', $output);
-        // $this->cli->run('type valet_diagnostics.txt | clip');
-        // $this->files->unlink('valet_diagnostics.txt');
+		// $this->files->put('valet_diagnostics.txt', $output);
+		// $this->cli->run('type valet_diagnostics.txt | clip');
+		// $this->files->unlink('valet_diagnostics.txt');
 
-        $this->afterRun();
-    }
+		$this->afterRun();
+	}
 
-    protected function beforeRun()
-    {
-        if ($this->print) {
-            return;
-        }
+	protected function beforeRun()
+	{
+		if ($this->print) {
+			return;
+		}
 
-        $this->progressBar = new ProgressBar(new ConsoleOutput, count($this->commands));
+		$this->progressBar = new ProgressBar(new ConsoleOutput, count($this->commands));
 
-        $this->progressBar->start();
-    }
+		$this->progressBar->start();
+	}
 
-    protected function afterRun()
-    {
-        if ($this->progressBar) {
-            $this->progressBar->finish();
-        }
+	protected function afterRun()
+	{
+		if ($this->progressBar) {
+			$this->progressBar->finish();
+		}
 
-        output('');
-    }
+		output('');
+	}
 
-    protected function runCommand($command)
-    {
-        return strpos($command, 'sudo ') === 0
-            ? $this->cli->run($command)
-            : $this->cli->runAsUser($command);
-    }
+	protected function runCommand($command)
+	{
+		return strpos($command, 'sudo ') === 0
+			? $this->cli->run($command)
+			: $this->cli->runAsUser($command);
+	}
 
-    protected function beforeCommand($command)
-    {
-        if ($this->print) {
-            info(PHP_EOL."$ $command");
-        }
-    }
+	protected function beforeCommand($command)
+	{
+		if ($this->print) {
+			info(PHP_EOL."$ $command");
+		}
+	}
 
-    protected function afterCommand($command, $output)
-    {
-        if ($this->print) {
-            output(trim($output));
-        } else {
-            $this->progressBar->advance();
-        }
-    }
+	protected function afterCommand($command, $output)
+	{
+		if ($this->print) {
+			output(trim($output));
+		} else {
+			$this->progressBar->advance();
+		}
+	}
 
-    protected function ignoreOutput($command)
-    {
-        return strpos($command, '> /dev/null 2>&1') !== false;
-    }
+	protected function ignoreOutput($command)
+	{
+		return strpos($command, '> /dev/null 2>&1') !== false;
+	}
 
-    protected function format($results, $plainText)
-    {
-        return $results->map(function ($result) use ($plainText) {
-            $command = $result['command'];
-            $output = trim($result['output']);
+	protected function format($results, $plainText)
+	{
+		return $results->map(function ($result) use ($plainText) {
+			$command = $result['command'];
+			$output = trim($result['output']);
 
-            if ($plainText) {
-                return implode(PHP_EOL, ["$ {$command}", $output]);
-            }
+			if ($plainText) {
+				return implode(PHP_EOL, ["$ {$command}", $output]);
+			}
 
-            return sprintf(
-                '<details>%s<summary>%s</summary>%s<pre>%s</pre>%s</details>',
-                PHP_EOL, $command, PHP_EOL, $output, PHP_EOL
-            );
-        })->implode($plainText ? PHP_EOL.str_repeat('-', 20).PHP_EOL : PHP_EOL);
-    }
+			return sprintf(
+				'<details>%s<summary>%s</summary>%s<pre>%s</pre>%s</details>',
+				PHP_EOL, $command, PHP_EOL, $output, PHP_EOL
+			);
+		})->implode($plainText ? PHP_EOL.str_repeat('-', 20).PHP_EOL : PHP_EOL);
+	}
 }

--- a/cli/Valet/Filesystem.php
+++ b/cli/Valet/Filesystem.php
@@ -4,356 +4,356 @@ namespace Valet;
 
 class Filesystem
 {
-    /**
-     * Determine if the given path is a directory.
-     *
-     * @param  string  $path
-     * @return bool
-     */
-    public function isDir($path)
-    {
-        return is_dir($path);
-    }
+	/**
+	 * Determine if the given path is a directory.
+	 *
+	 * @param  string  $path
+	 * @return bool
+	 */
+	public function isDir($path)
+	{
+		return is_dir($path);
+	}
 
-    /**
-     * Create a directory.
-     *
-     * @param  string  $path
-     * @param  string|null  $owner
-     * @param  int  $mode
-     * @return void
-     */
-    public function mkdir($path, $owner = null, $mode = 0755)
-    {
-        mkdir($path, $mode, true);
+	/**
+	 * Create a directory.
+	 *
+	 * @param  string  $path
+	 * @param  string|null  $owner
+	 * @param  int  $mode
+	 * @return void
+	 */
+	public function mkdir($path, $owner = null, $mode = 0755)
+	{
+		mkdir($path, $mode, true);
 
-        if ($owner) {
-            $this->chown($path, $owner);
-        }
-    }
+		if ($owner) {
+			$this->chown($path, $owner);
+		}
+	}
 
-    /**
-     * Ensure that the given directory exists.
-     *
-     * @param  string  $path
-     * @param  string|null  $owner
-     * @param  int  $mode
-     * @return void
-     */
-    public function ensureDirExists($path, $owner = null, $mode = 0755)
-    {
-        if (! $this->isDir($path)) {
-            $this->mkdir($path, $owner, $mode);
-        }
-    }
+	/**
+	 * Ensure that the given directory exists.
+	 *
+	 * @param  string  $path
+	 * @param  string|null  $owner
+	 * @param  int  $mode
+	 * @return void
+	 */
+	public function ensureDirExists($path, $owner = null, $mode = 0755)
+	{
+		if (! $this->isDir($path)) {
+			$this->mkdir($path, $owner, $mode);
+		}
+	}
 
-    /**
-     * Create a directory as the non-root user.
-     *
-     * @param  string  $path
-     * @param  int  $mode
-     * @return void
-     */
-    public function mkdirAsUser($path, $mode = 0755)
-    {
-        $this->mkdir($path, user(), $mode);
-    }
+	/**
+	 * Create a directory as the non-root user.
+	 *
+	 * @param  string  $path
+	 * @param  int  $mode
+	 * @return void
+	 */
+	public function mkdirAsUser($path, $mode = 0755)
+	{
+		$this->mkdir($path, user(), $mode);
+	}
 
-    /**
-     * Touch the given path.
-     *
-     * @param  string  $path
-     * @param  string|null  $owner
-     * @return string
-     */
-    public function touch($path, $owner = null)
-    {
-        touch($path);
+	/**
+	 * Touch the given path.
+	 *
+	 * @param  string  $path
+	 * @param  string|null  $owner
+	 * @return string
+	 */
+	public function touch($path, $owner = null)
+	{
+		touch($path);
 
-        if ($owner) {
-            $this->chown($path, $owner);
-        }
+		if ($owner) {
+			$this->chown($path, $owner);
+		}
 
-        return $path;
-    }
+		return $path;
+	}
 
-    /**
-     * Touch the given path as the non-root user.
-     *
-     * @param  string  $path
-     * @return void
-     */
-    public function touchAsUser($path)
-    {
-        return $this->touch($path, user());
-    }
+	/**
+	 * Touch the given path as the non-root user.
+	 *
+	 * @param  string  $path
+	 * @return void
+	 */
+	public function touchAsUser($path)
+	{
+		return $this->touch($path, user());
+	}
 
-    /**
-     * Determine if the given file exists.
-     *
-     * @param  string  $path
-     * @return bool
-     */
-    public function exists($path)
-    {
-        return file_exists($path);
-    }
+	/**
+	 * Determine if the given file exists.
+	 *
+	 * @param  string  $path
+	 * @return bool
+	 */
+	public function exists($path)
+	{
+		return file_exists($path);
+	}
 
-    /**
-     * Read the contents of the given file.
-     *
-     * @param  string  $path
-     * @return string
-     */
-    public function get($path)
-    {
-        return file_get_contents($path);
-    }
+	/**
+	 * Read the contents of the given file.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	public function get($path)
+	{
+		return file_get_contents($path);
+	}
 
-    /**
-     * Write to the given file.
-     *
-     * @param  string  $path
-     * @param  string  $contents
-     * @param  string|null  $owner
-     * @return void
-     */
-    public function put($path, $contents, $owner = null)
-    {
-        file_put_contents($path, $contents);
+	/**
+	 * Write to the given file.
+	 *
+	 * @param  string  $path
+	 * @param  string  $contents
+	 * @param  string|null  $owner
+	 * @return void
+	 */
+	public function put($path, $contents, $owner = null)
+	{
+		file_put_contents($path, $contents);
 
-        if ($owner) {
-            $this->chown($path, $owner);
-        }
-    }
+		if ($owner) {
+			$this->chown($path, $owner);
+		}
+	}
 
-    /**
-     * Write to the given file as the non-root user.
-     *
-     * @param  string  $path
-     * @param  string  $contents
-     * @return void
-     */
-    public function putAsUser($path, $contents)
-    {
-        $this->put($path, $contents, user());
-    }
+	/**
+	 * Write to the given file as the non-root user.
+	 *
+	 * @param  string  $path
+	 * @param  string  $contents
+	 * @return void
+	 */
+	public function putAsUser($path, $contents)
+	{
+		$this->put($path, $contents, user());
+	}
 
-    /**
-     * Append the contents to the given file.
-     *
-     * @param  string  $path
-     * @param  string  $contents
-     * @param  string|null  $owner
-     * @return void
-     */
-    public function append($path, $contents, $owner = null)
-    {
-        file_put_contents($path, $contents, FILE_APPEND);
+	/**
+	 * Append the contents to the given file.
+	 *
+	 * @param  string  $path
+	 * @param  string  $contents
+	 * @param  string|null  $owner
+	 * @return void
+	 */
+	public function append($path, $contents, $owner = null)
+	{
+		file_put_contents($path, $contents, FILE_APPEND);
 
-        if ($owner) {
-            $this->chown($path, $owner);
-        }
-    }
+		if ($owner) {
+			$this->chown($path, $owner);
+		}
+	}
 
-    /**
-     * Append the contents to the given file as the non-root user.
-     *
-     * @param  string  $path
-     * @param  string  $contents
-     * @return void
-     */
-    public function appendAsUser($path, $contents)
-    {
-        $this->append($path, $contents, user());
-    }
+	/**
+	 * Append the contents to the given file as the non-root user.
+	 *
+	 * @param  string  $path
+	 * @param  string  $contents
+	 * @return void
+	 */
+	public function appendAsUser($path, $contents)
+	{
+		$this->append($path, $contents, user());
+	}
 
-    /**
-     * Copy the given file to a new location.
-     *
-     * @param  string  $from
-     * @param  string  $to
-     * @return void
-     */
-    public function copy($from, $to)
-    {
-        copy($from, $to);
-    }
+	/**
+	 * Copy the given file to a new location.
+	 *
+	 * @param  string  $from
+	 * @param  string  $to
+	 * @return void
+	 */
+	public function copy($from, $to)
+	{
+		copy($from, $to);
+	}
 
-    /**
-     * Copy the given file to a new location for the non-root user.
-     *
-     * @param  string  $from
-     * @param  string  $to
-     * @return void
-     */
-    public function copyAsUser($from, $to)
-    {
-        copy($from, $to);
+	/**
+	 * Copy the given file to a new location for the non-root user.
+	 *
+	 * @param  string  $from
+	 * @param  string  $to
+	 * @return void
+	 */
+	public function copyAsUser($from, $to)
+	{
+		copy($from, $to);
 
-        $this->chown($to, user());
-    }
+		$this->chown($to, user());
+	}
 
-    /**
-     * Create a symlink to the given target.
-     *
-     * @param  string  $target
-     * @param  string  $link
-     * @return void
-     */
-    public function symlink($target, $link)
-    {
-        if ($this->exists($link)) {
-            $this->unlink($link);
-        }
+	/**
+	 * Create a symlink to the given target.
+	 *
+	 * @param  string  $target
+	 * @param  string  $link
+	 * @return void
+	 */
+	public function symlink($target, $link)
+	{
+		if ($this->exists($link)) {
+			$this->unlink($link);
+		}
 
-        symlink($target, $link);
-    }
+		symlink($target, $link);
+	}
 
-    /**
-     * Create a symlink to the given target for the non-root user.
-     *
-     * This uses the command line as PHP can't change symlink permissions.
-     *
-     * @param  string  $target
-     * @param  string  $link
-     * @return void
-     */
-    public function symlinkAsUser($target, $link)
-    {
-        if ($this->exists($link)) {
-            $this->unlink($link);
-        }
+	/**
+	 * Create a symlink to the given target for the non-root user.
+	 *
+	 * This uses the command line as PHP can't change symlink permissions.
+	 *
+	 * @param  string  $target
+	 * @param  string  $link
+	 * @return void
+	 */
+	public function symlinkAsUser($target, $link)
+	{
+		if ($this->exists($link)) {
+			$this->unlink($link);
+		}
 
-        $mode = is_dir($target) ? 'J' : 'H';
+		$mode = is_dir($target) ? 'J' : 'H';
 
-        exec("mklink /{$mode} \"{$link}\" \"{$target}\"");
-    }
+		exec("mklink /{$mode} \"{$link}\" \"{$target}\"");
+	}
 
-    /**
-     * Delete the file at the given path.
-     *
-     * @param  string  $path
-     * @return void
-     */
-    public function unlink($path)
-    {
-        if ($this->isLink($path)) {
-            $dir = pathinfo($path, PATHINFO_DIRNAME);
-            $link = pathinfo($path, PATHINFO_BASENAME);
+	/**
+	 * Delete the file at the given path.
+	 *
+	 * @param  string  $path
+	 * @return void
+	 */
+	public function unlink($path)
+	{
+		if ($this->isLink($path)) {
+			$dir = pathinfo($path, PATHINFO_DIRNAME);
+			$link = pathinfo($path, PATHINFO_BASENAME);
 
-            if (is_dir($path)) {
-                exec("cd \"{$dir}\" && rmdir {$link}");
-            } else {
-                @unlink($path);
-            }
-        } elseif ($this->isDir($path)) {
-            exec('cmd /C rmdir /s /q "'.$path.'"');
-        } elseif (file_exists($path)) {
-            @unlink($path);
-        }
-    }
+			if (is_dir($path)) {
+				exec("cd \"{$dir}\" && rmdir {$link}");
+			} else {
+				@unlink($path);
+			}
+		} elseif ($this->isDir($path)) {
+			exec('cmd /C rmdir /s /q "'.$path.'"');
+		} elseif (file_exists($path)) {
+			@unlink($path);
+		}
+	}
 
-    /**
-     * Change the owner of the given path.
-     *
-     * @param  string  $path
-     * @param  string  $user
-     * @return void
-     */
-    public function chown($path, $user)
-    {
-        chown($path, $user);
-    }
+	/**
+	 * Change the owner of the given path.
+	 *
+	 * @param  string  $path
+	 * @param  string  $user
+	 * @return void
+	 */
+	public function chown($path, $user)
+	{
+		chown($path, $user);
+	}
 
-    /**
-     * Change the group of the given path.
-     *
-     * @param  string  $path
-     * @param  string  $group
-     * @return void
-     */
-    public function chgrp($path, $group)
-    {
-        chgrp($path, $group);
-    }
+	/**
+	 * Change the group of the given path.
+	 *
+	 * @param  string  $path
+	 * @param  string  $group
+	 * @return void
+	 */
+	public function chgrp($path, $group)
+	{
+		chgrp($path, $group);
+	}
 
-    /**
-     * Resolve the given path.
-     *
-     * @param  string  $path
-     * @return string
-     */
-    public function realpath($path)
-    {
-        return realpath($path);
-    }
+	/**
+	 * Resolve the given path.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	public function realpath($path)
+	{
+		return realpath($path);
+	}
 
-    /**
-     * Determine if the given path is a symbolic link.
-     *
-     * @param  string  $path
-     * @return bool
-     */
-    public function isLink($path)
-    {
-        if (is_link($path)) {
-            return true;
-        }
+	/**
+	 * Determine if the given path is a symbolic link.
+	 *
+	 * @param  string  $path
+	 * @return bool
+	 */
+	public function isLink($path)
+	{
+		if (is_link($path)) {
+			return true;
+		}
 
-        return $this->isDir($path) && filesize($path) === 0;
-    }
+		return $this->isDir($path) && filesize($path) === 0;
+	}
 
-    /**
-     * Resolve the given symbolic link.
-     *
-     * @param  string  $path
-     * @return string
-     */
-    public function readLink($path)
-    {
-        return readlink($path);
-    }
+	/**
+	 * Resolve the given symbolic link.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	public function readLink($path)
+	{
+		return readlink($path);
+	}
 
-    /**
-     * Remove all of the broken symbolic links at the given path.
-     *
-     * @param  string  $path
-     * @return void
-     */
-    public function removeBrokenLinksAt($path)
-    {
-        collect($this->scandir($path))
-                ->filter(function ($file) use ($path) {
-                    return $this->isBrokenLink($path.'/'.$file);
-                })
-                ->each(function ($file) use ($path) {
-                    $this->unlink($path.'/'.$file);
-                });
-    }
+	/**
+	 * Remove all of the broken symbolic links at the given path.
+	 *
+	 * @param  string  $path
+	 * @return void
+	 */
+	public function removeBrokenLinksAt($path)
+	{
+		collect($this->scandir($path))
+				->filter(function ($file) use ($path) {
+					return $this->isBrokenLink($path.'/'.$file);
+				})
+				->each(function ($file) use ($path) {
+					$this->unlink($path.'/'.$file);
+				});
+	}
 
-    /**
-     * Determine if the given path is a broken symbolic link.
-     *
-     * @param  string  $path
-     * @return bool
-     */
-    public function isBrokenLink($path)
-    {
-        return is_link($path) || @readlink($path) === false;
-    }
+	/**
+	 * Determine if the given path is a broken symbolic link.
+	 *
+	 * @param  string  $path
+	 * @return bool
+	 */
+	public function isBrokenLink($path)
+	{
+		return is_link($path) || @readlink($path) === false;
+	}
 
-    /**
-     * Scan the given directory path.
-     *
-     * @param  string  $path
-     * @return array
-     */
-    public function scandir($path)
-    {
-        return collect(scandir($path))
-                    ->reject(function ($file) {
-                        return in_array($file, ['.', '..']);
-                    })->values()->all();
-    }
+	/**
+	 * Scan the given directory path.
+	 *
+	 * @param  string  $path
+	 * @return array
+	 */
+	public function scandir($path)
+	{
+		return collect(scandir($path))
+					->reject(function ($file) {
+						return in_array($file, ['.', '..']);
+					})->values()->all();
+	}
 }

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -4,219 +4,219 @@ namespace Valet;
 
 class Nginx
 {
-    /**
-     * @var CommandLine
-     */
-    protected $cli;
+	/**
+	 * @var CommandLine
+	 */
+	protected $cli;
 
-    /**
-     * @var Filesystem
-     */
-    protected $files;
+	/**
+	 * @var Filesystem
+	 */
+	protected $files;
 
-    /**
-     * @var Configuration
-     */
-    protected $configuration;
+	/**
+	 * @var Configuration
+	 */
+	protected $configuration;
 
-    /**
-     * @var Site
-     */
-    protected $site;
+	/**
+	 * @var Site
+	 */
+	protected $site;
 
-    /**
-     * @var WinSW
-     */
-    protected $winsw;
+	/**
+	 * @var WinSW
+	 */
+	protected $winsw;
 
-    /**
-     * Create a new Nginx instance.
-     *
-     * @param  CommandLine  $cli
-     * @param  Filesystem  $files
-     * @param  Configuration  $configuration
-     * @param  Site  $site
-     * @param  WinSW  $winsw
-     * @return void
-     */
-    public function __construct(CommandLine $cli, Filesystem $files,
-                         Configuration $configuration, Site $site, WinSwFactory $winsw)
-    {
-        $this->cli = $cli;
-        $this->site = $site;
-        $this->files = $files;
-        $this->winsw = $winsw->make('nginxservice');
-        $this->configuration = $configuration;
-    }
+	/**
+	 * Create a new Nginx instance.
+	 *
+	 * @param  CommandLine  $cli
+	 * @param  Filesystem  $files
+	 * @param  Configuration  $configuration
+	 * @param  Site  $site
+	 * @param  WinSW  $winsw
+	 * @return void
+	 */
+	public function __construct(CommandLine $cli, Filesystem $files,
+						 Configuration $configuration, Site $site, WinSwFactory $winsw)
+	{
+		$this->cli = $cli;
+		$this->site = $site;
+		$this->files = $files;
+		$this->winsw = $winsw->make('nginxservice');
+		$this->configuration = $configuration;
+	}
 
-    /**
-     * Install the configuration files for Nginx.
-     *
-     * @return void
-     */
-    public function install()
-    {
-        info('Installing Nginx...');
+	/**
+	 * Install the configuration files for Nginx.
+	 *
+	 * @return void
+	 */
+	public function install()
+	{
+		info('Installing Nginx...');
 
-        $this->installConfiguration();
-        $this->installServer();
-        $this->installNginxDirectory();
-        $this->installService();
-    }
+		$this->installConfiguration();
+		$this->installServer();
+		$this->installNginxDirectory();
+		$this->installService();
+	}
 
-    /**
-     * Install the Nginx configuration file.
-     *
-     * @return void
-     */
-    public function installConfiguration()
-    {
-        $defaultPhpVersion = $this->configuration->get('default_php');
-        $defaultPhp = $this->configuration->getPhpByVersion($defaultPhpVersion);
+	/**
+	 * Install the Nginx configuration file.
+	 *
+	 * @return void
+	 */
+	public function installConfiguration()
+	{
+		$defaultPhpVersion = $this->configuration->get('default_php');
+		$defaultPhp = $this->configuration->getPhpByVersion($defaultPhpVersion);
 
-        $this->files->putAsUser(
-            $this->path('conf/nginx.conf'),
-            str_replace(
-                ['VALET_USER', 'VALET_HOME_PATH', '__VALET_PHP_PORT__', '__VALET_PHP_XDEBUG_PORT__'],
-                [user(), VALET_HOME_PATH, $defaultPhp['port'], $defaultPhp['xdebug_port']],
-                $this->files->get(__DIR__.'/../stubs/nginx.conf')
-            )
-        );
-    }
+		$this->files->putAsUser(
+			$this->path('conf/nginx.conf'),
+			str_replace(
+				['VALET_USER', 'VALET_HOME_PATH', '__VALET_PHP_PORT__', '__VALET_PHP_XDEBUG_PORT__'],
+				[user(), VALET_HOME_PATH, $defaultPhp['port'], $defaultPhp['xdebug_port']],
+				$this->files->get(__DIR__.'/../stubs/nginx.conf')
+			)
+		);
+	}
 
-    /**
-     * Install the Valet Nginx server configuration file.
-     *
-     * @return void
-     */
-    public function installServer()
-    {
-        $defaultPhpVersion = $this->configuration->get('default_php');
-        $defaultPhp = $this->configuration->getPhpByVersion($defaultPhpVersion);
+	/**
+	 * Install the Valet Nginx server configuration file.
+	 *
+	 * @return void
+	 */
+	public function installServer()
+	{
+		$defaultPhpVersion = $this->configuration->get('default_php');
+		$defaultPhp = $this->configuration->getPhpByVersion($defaultPhpVersion);
 
-        $this->files->ensureDirExists($this->path('valet'));
+		$this->files->ensureDirExists($this->path('valet'));
 
-        $this->files->putAsUser(
-            $this->path('valet/valet.conf'),
-            str_replace(
-                ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'HOME_PATH', 'VALET_PHP_PORT'],
-                [VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX, $_SERVER['HOME'], $defaultPhp['port']],
-                $this->files->get(__DIR__.'/../stubs/valet.conf')
-            )
-        );
+		$this->files->putAsUser(
+			$this->path('valet/valet.conf'),
+			str_replace(
+				['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'HOME_PATH', 'VALET_PHP_PORT'],
+				[VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX, $_SERVER['HOME'], $defaultPhp['port']],
+				$this->files->get(__DIR__.'/../stubs/valet.conf')
+			)
+		);
 
-        $this->files->putAsUser(
-            $this->path().'/conf/fastcgi_params',
-            $this->files->get(__DIR__.'/../stubs/fastcgi_params')
-        );
-    }
+		$this->files->putAsUser(
+			$this->path().'/conf/fastcgi_params',
+			$this->files->get(__DIR__.'/../stubs/fastcgi_params')
+		);
+	}
 
-    /**
-     * Install the Nginx configuration directory to the ~/.config/valet directory.
-     *
-     * This directory contains all site-specific Nginx servers.
-     *
-     * @return void
-     */
-    public function installNginxDirectory()
-    {
-        if (! $this->files->isDir($nginxDirectory = Valet::homePath('Nginx'))) {
-            $this->files->mkdirAsUser($nginxDirectory);
-        }
+	/**
+	 * Install the Nginx configuration directory to the ~/.config/valet directory.
+	 *
+	 * This directory contains all site-specific Nginx servers.
+	 *
+	 * @return void
+	 */
+	public function installNginxDirectory()
+	{
+		if (! $this->files->isDir($nginxDirectory = Valet::homePath('Nginx'))) {
+			$this->files->mkdirAsUser($nginxDirectory);
+		}
 
-        $this->files->putAsUser($nginxDirectory.DIRECTORY_SEPARATOR.'.keep', "\n");
+		$this->files->putAsUser($nginxDirectory.DIRECTORY_SEPARATOR.'.keep', "\n");
 
-        $this->rewriteSecureNginxFiles();
-    }
+		$this->rewriteSecureNginxFiles();
+	}
 
-    /**
-     * Check nginx.conf for errors.
-     */
-    private function lint()
-    {
-        // TODO
-        // $this->cli->run(
-        //     'sudo nginx -c '.$this->path('conf/nginx.conf').' -t',
-        //     function ($exitCode, $outputMessage) {
-        //         throw new DomainException("Nginx cannot start; please check your nginx.conf [$exitCode: $outputMessage].");
-        //     }
-        // );
-    }
+	/**
+	 * Check nginx.conf for errors.
+	 */
+	private function lint()
+	{
+		// TODO
+		// $this->cli->run(
+		//     'sudo nginx -c '.$this->path('conf/nginx.conf').' -t',
+		//     function ($exitCode, $outputMessage) {
+		//         throw new DomainException("Nginx cannot start; please check your nginx.conf [$exitCode: $outputMessage].");
+		//     }
+		// );
+	}
 
-    /**
-     * Generate fresh Nginx servers for existing secure sites.
-     *
-     * @return void
-     */
-    public function rewriteSecureNginxFiles()
-    {
-        $tld = $this->configuration->read()['tld'];
+	/**
+	 * Generate fresh Nginx servers for existing secure sites.
+	 *
+	 * @return void
+	 */
+	public function rewriteSecureNginxFiles()
+	{
+		$tld = $this->configuration->read()['tld'];
 
-        $this->site->resecureForNewTld($tld, $tld);
-    }
+		$this->site->resecureForNewTld($tld, $tld);
+	}
 
-    /**
-     * Install the Windows service.
-     *
-     * @return void
-     */
-    public function installService()
-    {
-        if ($this->winsw->installed()) {
-            $this->uninstall();
-        }
+	/**
+	 * Install the Windows service.
+	 *
+	 * @return void
+	 */
+	public function installService()
+	{
+		if ($this->winsw->installed()) {
+			$this->uninstall();
+		}
 
-        $this->winsw->install([
-            'NGINX_PATH' => $this->path(),
-        ]);
+		$this->winsw->install([
+			'NGINX_PATH' => $this->path(),
+		]);
 
-        $this->winsw->restart();
-    }
+		$this->winsw->restart();
+	}
 
-    /**
-     * Restart the Nginx service.
-     *
-     * @return void
-     */
-    public function restart()
-    {
-        $this->cli->run('cmd "/C taskkill /IM nginx.exe /F"');
+	/**
+	 * Restart the Nginx service.
+	 *
+	 * @return void
+	 */
+	public function restart()
+	{
+		$this->cli->run('cmd "/C taskkill /IM nginx.exe /F"');
 
-        $this->winsw->restart();
-    }
+		$this->winsw->restart();
+	}
 
-    /**
-     * Stop the Nginx service.
-     *
-     * @return void
-     */
-    public function stop()
-    {
-        $this->cli->run('cmd "/C taskkill /IM nginx.exe /F"');
+	/**
+	 * Stop the Nginx service.
+	 *
+	 * @return void
+	 */
+	public function stop()
+	{
+		$this->cli->run('cmd "/C taskkill /IM nginx.exe /F"');
 
-        $this->winsw->stop();
-    }
+		$this->winsw->stop();
+	}
 
-    /**
-     * Prepare Nginx for uninstallation.
-     *
-     * @return void
-     */
-    public function uninstall()
-    {
-        $this->cli->run('cmd "/C taskkill /IM nginx.exe /F"');
+	/**
+	 * Prepare Nginx for uninstallation.
+	 *
+	 * @return void
+	 */
+	public function uninstall()
+	{
+		$this->cli->run('cmd "/C taskkill /IM nginx.exe /F"');
 
-        $this->winsw->uninstall();
-    }
+		$this->winsw->uninstall();
+	}
 
-    /**
-     * Get the Nginx path.
-     *
-     * @param  string  $path
-     * @return string
-     */
-    public function path(string $path = ''): string
-    {
-        return realpath(__DIR__.'/../../bin/nginx').($path ? DIRECTORY_SEPARATOR.$path : $path);
-    }
+	/**
+	 * Get the Nginx path.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	public function path(string $path = ''): string
+	{
+		return realpath(__DIR__.'/../../bin/nginx').($path ? DIRECTORY_SEPARATOR.$path : $path);
+	}
 }

--- a/cli/Valet/Ngrok.php
+++ b/cli/Valet/Ngrok.php
@@ -8,116 +8,116 @@ use Illuminate\Support\Collection;
 
 class Ngrok
 {
-    /**
-     * @var CommandLine
-     */
-    protected $cli;
+	/**
+	 * @var CommandLine
+	 */
+	protected $cli;
 
-    /**
-     * @var array
-     */
-    protected $tunnelsEndpoints = [
-        'http://127.0.0.1:4040/api/tunnels',
-        'http://127.0.0.1:4041/api/tunnels',
-    ];
+	/**
+	 * @var array
+	 */
+	protected $tunnelsEndpoints = [
+		'http://127.0.0.1:4040/api/tunnels',
+		'http://127.0.0.1:4041/api/tunnels',
+	];
 
-    /**
-     * Create a new Nginx instance.
-     *
-     * @param  CommandLine  $cli
-     * @return void
-     */
-    public function __construct(CommandLine $cli)
-    {
-        $this->cli = $cli;
-    }
+	/**
+	 * Create a new Nginx instance.
+	 *
+	 * @param  CommandLine  $cli
+	 * @return void
+	 */
+	public function __construct(CommandLine $cli)
+	{
+		$this->cli = $cli;
+	}
 
-    /**
-     * @param  string  $command
-     * @return void
-     */
-    public function run(string $command)
-    {
-        $ngrok = realpath(__DIR__.'/../../bin/ngrok.exe');
+	/**
+	 * @param  string  $command
+	 * @return void
+	 */
+	public function run(string $command)
+	{
+		$ngrok = realpath(__DIR__.'/../../bin/ngrok.exe');
 
-        $this->cli->passthru("\"$ngrok\" $command");
-    }
+		$this->cli->passthru("\"$ngrok\" $command");
+	}
 
-    /**
-     * @param  string  $domain
-     * @param  int  $port
-     * @param  array  $options
-     * @return void
-     */
-    public function start(string $domain, int $port, array $options = [])
-    {
-        if ($port === 443 && ! $this->hasAuthToken()) {
-            output('Forwarding to local port 443 or a local https:// URL is only available after you sign up.
+	/**
+	 * @param  string  $domain
+	 * @param  int  $port
+	 * @param  array  $options
+	 * @return void
+	 */
+	public function start(string $domain, int $port, array $options = [])
+	{
+		if ($port === 443 && ! $this->hasAuthToken()) {
+			output('Forwarding to local port 443 or a local https:// URL is only available after you sign up.
 Sign up at: https://ngrok.com/signup
 Then use: valet ngrok authtoken my-token');
-            exit(1);
-        }
+			exit(1);
+		}
 
-        $options = (new Collection($options))->map(function ($value, $key) {
-            return "--$key=$value";
-        })->implode(' ');
+		$options = (new Collection($options))->map(function ($value, $key) {
+			return "--$key=$value";
+		})->implode(' ');
 
-        $ngrok = realpath(__DIR__.'/../../bin/ngrok.exe');
+		$ngrok = realpath(__DIR__.'/../../bin/ngrok.exe');
 
-        $this->cli->passthru("start \"$domain\" \"$ngrok\" http $domain:$port $options");
-    }
+		$this->cli->passthru("start \"$domain\" \"$ngrok\" http $domain:$port $options");
+	}
 
-    /**
-     * Get the current tunnel URL from the Ngrok API.
-     *
-     * @return string
-     */
-    public function currentTunnelUrl(string $domain = null)
-    {
-        // wait a second for ngrok to start before attempting to find available tunnels
-        // sleep(1);
+	/**
+	 * Get the current tunnel URL from the Ngrok API.
+	 *
+	 * @return string
+	 */
+	public function currentTunnelUrl(string $domain = null)
+	{
+		// wait a second for ngrok to start before attempting to find available tunnels
+		// sleep(1);
 
-        foreach ($this->tunnelsEndpoints as $endpoint) {
-            $response = retry(20, function () use ($endpoint, $domain) {
-                $body = Request::get($endpoint)->send()->body;
+		foreach ($this->tunnelsEndpoints as $endpoint) {
+			$response = retry(20, function () use ($endpoint, $domain) {
+				$body = Request::get($endpoint)->send()->body;
 
-                if (isset($body->tunnels) && count($body->tunnels) > 0) {
-                    return $this->findHttpTunnelUrl($body->tunnels, $domain);
-                }
-            }, 250);
+				if (isset($body->tunnels) && count($body->tunnels) > 0) {
+					return $this->findHttpTunnelUrl($body->tunnels, $domain);
+				}
+			}, 250);
 
-            if (! empty($response)) {
-                return $response;
-            }
-        }
+			if (! empty($response)) {
+				return $response;
+			}
+		}
 
-        throw new DomainException('Tunnel not established.');
-    }
+		throw new DomainException('Tunnel not established.');
+	}
 
-    /**
-     * Find the HTTP tunnel URL from the list of tunnels.
-     *
-     * @param  array  $tunnels
-     * @return string|null
-     * @return void
-     */
-    public function findHttpTunnelUrl(array $tunnels, string $domain = null)
-    {
-        // If there are active tunnels on the Ngrok instance we will spin through them and
-        // find the one responding on HTTP. Each tunnel has an HTTP and a HTTPS address
-        // but for local dev purposes we just desire the plain HTTP URL endpoint.
-        foreach ($tunnels as $tunnel) {
-            if ($tunnel->proto === 'http' && strpos($tunnel->config->addr, $domain)) {
-                return $tunnel->public_url;
-            }
-        }
-    }
+	/**
+	 * Find the HTTP tunnel URL from the list of tunnels.
+	 *
+	 * @param  array  $tunnels
+	 * @return string|null
+	 * @return void
+	 */
+	public function findHttpTunnelUrl(array $tunnels, string $domain = null)
+	{
+		// If there are active tunnels on the Ngrok instance we will spin through them and
+		// find the one responding on HTTP. Each tunnel has an HTTP and a HTTPS address
+		// but for local dev purposes we just desire the plain HTTP URL endpoint.
+		foreach ($tunnels as $tunnel) {
+			if ($tunnel->proto === 'http' && strpos($tunnel->config->addr, $domain)) {
+				return $tunnel->public_url;
+			}
+		}
+	}
 
-    /**
-     * @return bool
-     */
-    protected function hasAuthToken(): bool
-    {
-        return file_exists($_SERVER['HOME'].'/.ngrok2/ngrok.yml');
-    }
+	/**
+	 * @return bool
+	 */
+	protected function hasAuthToken(): bool
+	{
+		return file_exists($_SERVER['HOME'].'/.ngrok2/ngrok.yml');
+	}
 }

--- a/cli/Valet/PhpCgi.php
+++ b/cli/Valet/PhpCgi.php
@@ -6,219 +6,219 @@ use Symfony\Component\Process\PhpExecutableFinder;
 
 class PhpCgi
 {
-    const PORT = 9001;
+	const PORT = 9001;
 
-    /**
-     * @var CommandLine
-     */
-    protected $cli;
+	/**
+	 * @var CommandLine
+	 */
+	protected $cli;
 
-    /**
-     * @var Filesystem
-     */
-    protected $files;
+	/**
+	 * @var Filesystem
+	 */
+	protected $files;
 
-    /**
-     * @var WinSW
-     */
-    protected $winsw;
+	/**
+	 * @var WinSW
+	 */
+	protected $winsw;
 
-    /**
-     * @var WinSwFactory
-     */
-    protected $winswFactory;
+	/**
+	 * @var WinSwFactory
+	 */
+	protected $winswFactory;
 
-    /**@var array
-     */
-    protected $phpWinSws;
+	/**@var array
+	 */
+	protected $phpWinSws;
 
-    /**
-     * @var Configuration
-     */
-    protected $configuration;
+	/**
+	 * @var Configuration
+	 */
+	protected $configuration;
 
-    /**
-     * Create a new PHP CGI class instance.
-     *
-     * @param  CommandLine  $cli
-     * @param  Filesystem  $files
-     * @param  WinSwFactory  $winsw
-     * @param  Configuration  $configuration
-     * @return void
-     */
-    public function __construct(CommandLine $cli, Filesystem $files, WinSwFactory $winswFactory, Configuration $configuration)
-    {
-        $this->cli = $cli;
-        $this->files = $files;
-        $this->winswFactory = $winswFactory;
-        $this->configuration = $configuration;
+	/**
+	 * Create a new PHP CGI class instance.
+	 *
+	 * @param  CommandLine  $cli
+	 * @param  Filesystem  $files
+	 * @param  WinSwFactory  $winsw
+	 * @param  Configuration  $configuration
+	 * @return void
+	 */
+	public function __construct(CommandLine $cli, Filesystem $files, WinSwFactory $winswFactory, Configuration $configuration)
+	{
+		$this->cli = $cli;
+		$this->files = $files;
+		$this->winswFactory = $winswFactory;
+		$this->configuration = $configuration;
 
-        $phps = $this->configuration->get('php', []);
+		$phps = $this->configuration->get('php', []);
 
-        foreach ($phps as $php) {
-            $phpServiceName = "php{$php['version']}cgiservice";
-            $phpXdebugServiceName = "php{$php['version']}cgixdebugservice";
+		foreach ($phps as $php) {
+			$phpServiceName = "php{$php['version']}cgiservice";
+			$phpXdebugServiceName = "php{$php['version']}cgixdebugservice";
 
-            $this->phpWinSws[$php['version']] = [
-                'phpServiceName' => $phpServiceName,
-                'phpCgiName' => "valet_php{$php['version']}cgi-{$php['port']}",
-                'php' => $php,
-                'winsw' => $this->winswFactory->make($phpServiceName),
-            ];
-        }
-    }
+			$this->phpWinSws[$php['version']] = [
+				'phpServiceName' => $phpServiceName,
+				'phpCgiName' => "valet_php{$php['version']}cgi-{$php['port']}",
+				'php' => $php,
+				'winsw' => $this->winswFactory->make($phpServiceName),
+			];
+		}
+	}
 
-    /**
-     * Install and configure PHP CGI service.
-     *
-     * @return void
-     */
-    public function install($phpVersion = null)
-    {
-        $phps = $this->configuration->get('php', []);
+	/**
+	 * Install and configure PHP CGI service.
+	 *
+	 * @return void
+	 */
+	public function install($phpVersion = null)
+	{
+		$phps = $this->configuration->get('php', []);
 
-        if ($phpVersion) {
-            if (! isset($this->phpWinSws[$phpVersion])) {
-                warning("PHP service for version {$phpVersion} not found");
-            }
+		if ($phpVersion) {
+			if (! isset($this->phpWinSws[$phpVersion])) {
+				warning("PHP service for version {$phpVersion} not found");
+			}
 
-            $this->installService($phpVersion);
+			$this->installService($phpVersion);
 
-            return;
-        }
+			return;
+		}
 
-        foreach ($phps as $php) {
-            $this->installService($php['version']);
-        }
-    }
+		foreach ($phps as $php) {
+			$this->installService($php['version']);
+		}
+	}
 
-    /**
-     * Install the Windows service.
-     *
-     * @return void
-     */
-    public function installService($phpVersion, $phpCgiServiceConfig = null, $installConfig = null)
-    {
-        $phpWinSw = $this->phpWinSws[$phpVersion];
+	/**
+	 * Install the Windows service.
+	 *
+	 * @return void
+	 */
+	public function installService($phpVersion, $phpCgiServiceConfig = null, $installConfig = null)
+	{
+		$phpWinSw = $this->phpWinSws[$phpVersion];
 
-        if ($phpWinSw['winsw']->installed()) {
-            $phpWinSw['winsw']->uninstall();
-        }
+		if ($phpWinSw['winsw']->installed()) {
+			$phpWinSw['winsw']->uninstall();
+		}
 
-        // copy default phpcgiservice stub to create a new one
-        $phpCgiServiceConfigArgs['PHPCGINAME'] = $phpWinSw['phpCgiName'];
-        $phpCgiServiceConfig = $phpCgiServiceConfig ?? file_get_contents(__DIR__.'/../stubs/phpcgiservice.xml');
+		// copy default phpcgiservice stub to create a new one
+		$phpCgiServiceConfigArgs['PHPCGINAME'] = $phpWinSw['phpCgiName'];
+		$phpCgiServiceConfig = $phpCgiServiceConfig ?? file_get_contents(__DIR__.'/../stubs/phpcgiservice.xml');
 
-        $this->files->put(
-            (__DIR__."/../stubs/{$phpWinSw['phpServiceName']}.xml"),
-            str_replace(array_keys($phpCgiServiceConfigArgs), array_values($phpCgiServiceConfigArgs), $phpCgiServiceConfig ?: '')
-        );
+		$this->files->put(
+			(__DIR__."/../stubs/{$phpWinSw['phpServiceName']}.xml"),
+			str_replace(array_keys($phpCgiServiceConfigArgs), array_values($phpCgiServiceConfigArgs), $phpCgiServiceConfig ?: '')
+		);
 
-        info("Installing PHP-CGI [{$phpWinSw['phpCgiName']}] service...");
+		info("Installing PHP-CGI [{$phpWinSw['phpCgiName']}] service...");
 
-        $phpWinSw['winsw']->install($installConfig ?? [
-            'PHP_PATH' => $phpWinSw['php']['path'],
-            'PHP_PORT' => $phpWinSw['php']['port'],
-        ]);
+		$phpWinSw['winsw']->install($installConfig ?? [
+			'PHP_PATH' => $phpWinSw['php']['path'],
+			'PHP_PORT' => $phpWinSw['php']['port'],
+		]);
 
-        $phpWinSw['winsw']->restart();
-    }
+		$phpWinSw['winsw']->restart();
+	}
 
-    /**
-     * Uninstall the PHP CGI service.
-     *
-     * @return void
-     */
-    public function uninstall($phpVersion = null)
-    {
-        if ($phpVersion) {
-            if (! isset($this->phpWinSws[$phpVersion])) {
-                warning("PHP service for version [{$phpVersion}] not found");
-            }
-            $this->uninstallService($phpVersion);
+	/**
+	 * Uninstall the PHP CGI service.
+	 *
+	 * @return void
+	 */
+	public function uninstall($phpVersion = null)
+	{
+		if ($phpVersion) {
+			if (! isset($this->phpWinSws[$phpVersion])) {
+				warning("PHP service for version [{$phpVersion}] not found");
+			}
+			$this->uninstallService($phpVersion);
 
-            return;
-        }
+			return;
+		}
 
-        $phps = $this->configuration->get('php', []);
+		$phps = $this->configuration->get('php', []);
 
-        foreach ($phps as $php) {
-            $this->uninstallService($php['version']);
-        }
-    }
+		foreach ($phps as $php) {
+			$this->uninstallService($php['version']);
+		}
+	}
 
-    /**
-     * Install the Windows service.
-     *
-     * @return void
-     */
-    public function uninstallService($phpVersion)
-    {
-        $phpWinSw = $this->phpWinSws[$phpVersion];
+	/**
+	 * Install the Windows service.
+	 *
+	 * @return void
+	 */
+	public function uninstallService($phpVersion)
+	{
+		$phpWinSw = $this->phpWinSws[$phpVersion];
 
-        info("Uninstalling PHP-CGI [{$phpWinSw['phpCgiName']}] service...");
+		info("Uninstalling PHP-CGI [{$phpWinSw['phpCgiName']}] service...");
 
-        $phpWinSw['winsw']->uninstall();
-    }
+		$phpWinSw['winsw']->uninstall();
+	}
 
-    /**
-     * Restart the PHP CGI service.
-     *
-     * @return void
-     */
-    public function restart()
-    {
-        foreach ($this->phpWinSws as $phpWinSw) {
-            $phpWinSw['winsw']->restart();
-        }
-    }
+	/**
+	 * Restart the PHP CGI service.
+	 *
+	 * @return void
+	 */
+	public function restart()
+	{
+		foreach ($this->phpWinSws as $phpWinSw) {
+			$phpWinSw['winsw']->restart();
+		}
+	}
 
-    /**
-     * Stop the PHP CGI service.
-     *
-     * @return void
-     */
-    public function stop()
-    {
-        foreach ($this->phpWinSws as $phpWinSw) {
-            $phpWinSw['winsw']->stop();
-        }
-    }
+	/**
+	 * Stop the PHP CGI service.
+	 *
+	 * @return void
+	 */
+	public function stop()
+	{
+		foreach ($this->phpWinSws as $phpWinSw) {
+			$phpWinSw['winsw']->stop();
+		}
+	}
 
-    /**
-     * Find the PHP path.
-     *
-     * @return string
-     */
-    public function findDefaultPhpPath(): string
-    {
-        if (! $php = (new PhpExecutableFinder)->find()) {
-            $php = $this->cli->runOrExit('where php', function () {
-                error('Failed to find PHP. Make sure it\'s added to the path environment variables.');
-            });
-        }
+	/**
+	 * Find the PHP path.
+	 *
+	 * @return string
+	 */
+	public function findDefaultPhpPath(): string
+	{
+		if (! $php = (new PhpExecutableFinder)->find()) {
+			$php = $this->cli->runOrExit('where php', function () {
+				error('Failed to find PHP. Make sure it\'s added to the path environment variables.');
+			});
+		}
 
-        return pathinfo(explode("\n", $php)[0], PATHINFO_DIRNAME);
-    }
+		return pathinfo(explode("\n", $php)[0], PATHINFO_DIRNAME);
+	}
 
-    /**
-     * Find the PHP path.
-     *
-     * @return mixed
-     */
-    public function findPhpVersion($phpPath)
-    {
-        $phpExecPath = "{$phpPath}\php.exe";
-        if (! file_exists($phpExecPath)) {
-            error("Failed to find the PHP executable in {$phpPath}");
+	/**
+	 * Find the PHP path.
+	 *
+	 * @return mixed
+	 */
+	public function findPhpVersion($phpPath)
+	{
+		$phpExecPath = "{$phpPath}\php.exe";
+		if (! file_exists($phpExecPath)) {
+			error("Failed to find the PHP executable in {$phpPath}");
 
-            return null;
-        }
+			return null;
+		}
 
-        $phpVersion = $this->cli->runOrExit("{$phpExecPath} -r \"echo PHP_VERSION;\"", function ($code, $output) use ($phpPath) {
-            error("Failed to find the PHP version for {$phpPath}");
-        });
+		$phpVersion = $this->cli->runOrExit("{$phpExecPath} -r \"echo PHP_VERSION;\"", function ($code, $output) use ($phpPath) {
+			error("Failed to find the PHP version for {$phpPath}");
+		});
 
-        return $phpVersion->getOutput();
-    }
+		return $phpVersion->getOutput();
+	}
 }

--- a/cli/Valet/PhpCgiXdebug.php
+++ b/cli/Valet/PhpCgiXdebug.php
@@ -4,63 +4,63 @@ namespace Valet;
 
 class PhpCgiXdebug extends PhpCgi
 {
-    const PORT = 9100;
+	const PORT = 9100;
 
-    /**
-     * @inheritDoc
-     */
-    public function __construct(CommandLine $cli, Filesystem $files, WinSwFactory $winswFactory, Configuration $configuration)
-    {
-        parent::__construct($cli, $files, $winswFactory, $configuration);
+	/**
+	 * @inheritDoc
+	 */
+	public function __construct(CommandLine $cli, Filesystem $files, WinSwFactory $winswFactory, Configuration $configuration)
+	{
+		parent::__construct($cli, $files, $winswFactory, $configuration);
 
-        foreach ($this->phpWinSws as $phpVersion => $phpWinSw) {
-            $phpServiceName = "php{$phpVersion}cgixdebugservice";
+		foreach ($this->phpWinSws as $phpVersion => $phpWinSw) {
+			$phpServiceName = "php{$phpVersion}cgixdebugservice";
 
-            $this->phpWinSws[$phpVersion]['phpServiceName'] = $phpServiceName;
-            $this->phpWinSws[$phpVersion]['phpCgiName'] = "valet_php{$phpVersion}cgi_xdebug-{$phpWinSw['php']['xdebug_port']}";
-            $this->phpWinSws[$phpVersion]['winsw'] = $this->winswFactory->make($phpServiceName);
-        }
-    }
+			$this->phpWinSws[$phpVersion]['phpServiceName'] = $phpServiceName;
+			$this->phpWinSws[$phpVersion]['phpCgiName'] = "valet_php{$phpVersion}cgi_xdebug-{$phpWinSw['php']['xdebug_port']}";
+			$this->phpWinSws[$phpVersion]['winsw'] = $this->winswFactory->make($phpServiceName);
+		}
+	}
 
-    /**
-     * Install and configure PHP CGI service.
-     *
-     * @return void
-     */
-    public function install($phpVersion = null)
-    {
-        $phps = $this->configuration->get('php', []);
+	/**
+	 * Install and configure PHP CGI service.
+	 *
+	 * @return void
+	 */
+	public function install($phpVersion = null)
+	{
+		$phps = $this->configuration->get('php', []);
 
-        if ($phpVersion) {
-            if (! isset($this->phpWinSws[$phpVersion])) {
-                warning("PHP xDebug service for version {$phpVersion} not found");
-            }
+		if ($phpVersion) {
+			if (! isset($this->phpWinSws[$phpVersion])) {
+				warning("PHP xDebug service for version {$phpVersion} not found");
+			}
 
-            $this->installService($phpVersion);
+			$this->installService($phpVersion);
 
-            return;
-        }
+			return;
+		}
 
-        foreach ($phps as $php) {
-            $this->installService($php['version']);
-        }
-    }
+		foreach ($phps as $php) {
+			$this->installService($php['version']);
+		}
+	}
 
-    /**
-     * Install the Windows service.
-     *
-     * @return void
-     */
-    public function installService($phpVersion, $phpCgiServiceConfig = null, $installConfig = null)
-    {
-        $phpWinSw = $this->phpWinSws[$phpVersion];
+	/**
+	 * Install the Windows service.
+	 *
+	 * @return void
+	 */
+	public function installService($phpVersion, $phpCgiServiceConfig = null, $installConfig = null)
+	{
+		$phpWinSw = $this->phpWinSws[$phpVersion];
 
-        $phpCgiServiceConfig = $phpCgiServiceConfig ?? file_get_contents(__DIR__.'/../stubs/phpcgixdebugservice.xml');
-        $installConfig = $installConfig ?? [
-            'PHP_PATH' => $phpWinSw['php']['path'],
-            'PHP_XDEBUG_PORT' => $phpWinSw['php']['xdebug_port'],
-        ];
+		$phpCgiServiceConfig = $phpCgiServiceConfig ?? file_get_contents(__DIR__.'/../stubs/phpcgixdebugservice.xml');
+		$installConfig = $installConfig ?? [
+			'PHP_PATH' => $phpWinSw['php']['path'],
+			'PHP_XDEBUG_PORT' => $phpWinSw['php']['xdebug_port'],
+		];
 
-        parent::installService($phpVersion, $phpCgiServiceConfig, $installConfig);
-    }
+		parent::installService($phpVersion, $phpCgiServiceConfig, $installConfig);
+	}
 }

--- a/cli/Valet/ProcessOutput.php
+++ b/cli/Valet/ProcessOutput.php
@@ -6,59 +6,59 @@ use Symfony\Component\Process\Process;
 
 class ProcessOutput
 {
-    /**
-     * @var \Symfony\Component\Process\Process
-     */
-    public $process;
+	/**
+	 * @var \Symfony\Component\Process\Process
+	 */
+	public $process;
 
-    /**
-     * Create a new test process instance.
-     *
-     * @param  \Symfony\Component\Process\Process  $process
-     * @return void
-     */
-    public function __construct(Process $process)
-    {
-        $this->process = $process;
-    }
+	/**
+	 * Create a new test process instance.
+	 *
+	 * @param  \Symfony\Component\Process\Process  $process
+	 * @return void
+	 */
+	public function __construct(Process $process)
+	{
+		$this->process = $process;
+	}
 
-    /**
-     * @return bool
-     */
-    public function isSuccessful(): bool
-    {
-        return $this->process->isSuccessful();
-    }
+	/**
+	 * @return bool
+	 */
+	public function isSuccessful(): bool
+	{
+		return $this->process->isSuccessful();
+	}
 
-    /**
-     * @return string
-     */
-    public function getOutput(): string
-    {
-        if ($this->process->isSuccessful()) {
-            return $this->process->getOutput();
-        }
+	/**
+	 * @return string
+	 */
+	public function getOutput(): string
+	{
+		if ($this->process->isSuccessful()) {
+			return $this->process->getOutput();
+		}
 
-        return $this->process->getErrorOutput();
-    }
+		return $this->process->getErrorOutput();
+	}
 
-    /**
-     * @return string
-     */
-    public function __toString()
-    {
-        return $this->getOutput();
-    }
+	/**
+	 * @return string
+	 */
+	public function __toString()
+	{
+		return $this->getOutput();
+	}
 
-    /**
-     * Handle dynamic calls into macros or pass missing methods to the base process.
-     *
-     * @param  string  $method
-     * @param  array  $args
-     * @return mixed
-     */
-    public function __call($method, $args)
-    {
-        return $this->process->{$method}(...$args);
-    }
+	/**
+	 * Handle dynamic calls into macros or pass missing methods to the base process.
+	 *
+	 * @param  string  $method
+	 * @param  array  $args
+	 * @return mixed
+	 */
+	public function __call($method, $args)
+	{
+		return $this->process->{$method}(...$args);
+	}
 }

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -296,10 +296,12 @@ class Site
         })->map(function ($path, $site) use ($certs, $config) {
             $secured = $certs->has($site);
             $url = ($secured ? 'https' : 'http').'://'.$site.'.'.$config['tld'];
+            $phpVersion = $this->customPhpVersion($site.'.'.$config['tld']);
 
             return [
                 'site' => $site,
                 'secured' => $secured ? ' X' : '',
+                'php' => $phpVersion,
                 'url' => $url,
                 'path' => $path,
             ];

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -302,7 +302,7 @@ class Site
             return [
                 'site' => $site,
                 'secured' => $secured ? ' X' : '',
-                'php' => $phpVersion ? "$phpVersion <info>(isolated)</info>" : "$defaultVersion (default)",
+                'php' => $phpVersion ? "<info>$phpVersion (isolated)</info>" : "$defaultVersion (default)",
                 'url' => $url,
                 'path' => $path,
             ];

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -8,942 +8,994 @@ use phpseclib3\File\X509;
 
 class Site
 {
-    protected $config;
-    protected $cli;
-    protected $files;
+	protected $config;
+	protected $cli;
+	protected $files;
 
-    /**
-     * Create a new Site instance.
-     *
-     * @param  Configuration  $config
-     * @param  CommandLine  $cli
-     * @param  Filesystem  $files
-     * @return void
-     */
-    public function __construct(Configuration $config, CommandLine $cli, Filesystem $files)
-    {
-        $this->cli = $cli;
-        $this->files = $files;
-        $this->config = $config;
-    }
+	/**
+	 * Create a new Site instance.
+	 *
+	 * @param  Configuration  $config
+	 * @param  CommandLine  $cli
+	 * @param  Filesystem  $files
+	 * @return void
+	 */
+	public function __construct(Configuration $config, CommandLine $cli, Filesystem $files)
+	{
+		$this->cli = $cli;
+		$this->files = $files;
+		$this->config = $config;
+	}
 
-    /**
-     * Get the name of the site.
-     *
-     * @param  string|null  $name
-     * @return string
-     */
-    private function getRealSiteName($name)
-    {
-        if (! is_null($name)) {
-            return $name;
-        }
+	/**
+	 * Get the name of the site.
+	 *
+	 * @param  string|null  $name
+	 * @return string
+	 */
+	private function getRealSiteName($name)
+	{
+		if (!is_null($name)) {
+			return $name;
+		}
 
-        if (is_string($link = $this->getLinkNameByCurrentDir())) {
-            return $link;
-        }
+		if (is_string($link = $this->getLinkNameByCurrentDir())) {
+			return $link;
+		}
 
-        return basename(getcwd());
-    }
+		return basename(getcwd());
+	}
 
-    /**
-     * Get link name based on the current directory.
-     *
-     * @return null|string
-     */
-    private function getLinkNameByCurrentDir()
-    {
-        $count = count($links = $this->links()->where('path', getcwd()));
+	/**
+	 * Get link name based on the current directory.
+	 *
+	 * @return null|string
+	 */
+	private function getLinkNameByCurrentDir()
+	{
+		$count = count($links = $this->links()->where('path', getcwd()));
 
-        if ($count == 1) {
-            return $links->shift()['site'];
-        }
+		if ($count == 1) {
+			return $links->shift()['site'];
+		}
 
-        if ($count > 1) {
-            throw new DomainException("There are {$count} links related to the current directory, please specify the name: valet unlink <name>.");
-        }
-    }
+		if ($count > 1) {
+			throw new DomainException("There are {$count} links related to the current directory, please specify the name: valet unlink <name>.");
+		}
+	}
 
-    /**
-     * Get the real hostname for the given path, checking links.
-     *
-     * @param  string  $path
-     * @return string|null
-     */
-    public function host($path)
-    {
-        foreach ($this->files->scandir($this->sitesPath()) as $link) {
-            if ($resolved = realpath($this->sitesPath($link)) === $path) {
-                return $link;
-            }
-        }
+	/**
+	 * Get the real hostname for the given path, checking links.
+	 *
+	 * @param  string  $path
+	 * @return string|null
+	 */
+	public function host($path)
+	{
+		foreach ($this->files->scandir($this->sitesPath()) as $link) {
+			if ($resolved = realpath($this->sitesPath($link)) === $path) {
+				return $link;
+			}
+		}
 
-        return basename($path);
-    }
+		return basename($path);
+	}
 
-    /**
-     * Link the current working directory with the given name.
-     *
-     * @param  string  $target
-     * @param  string  $link
-     * @return string
-     */
-    public function link($target, $link)
-    {
-        $this->files->ensureDirExists(
-            $linkPath = $this->sitesPath(), user()
-        );
+	/**
+	 * Link the current working directory with the given name.
+	 *
+	 * @param  string  $target
+	 * @param  string  $link
+	 * @return string
+	 */
+	public function link($target, $link)
+	{
+		$this->files->ensureDirExists(
+			$linkPath = $this->sitesPath(),
+			user()
+		);
 
-        $this->config->prependPath($linkPath);
+		$this->config->prependPath($linkPath);
 
-        $this->files->symlinkAsUser($target, $linkPath.'/'.$link);
+		$this->files->symlinkAsUser($target, $linkPath . '/' . $link);
 
-        return $linkPath.'/'.$link;
-    }
+		return $linkPath . '/' . $link;
+	}
 
-    /**
-     * Pretty print out all links in Valet.
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function links()
-    {
-        $certsPath = $this->certificatesPath();
+	/**
+	 * Pretty print out all links in Valet.
+	 *
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function links()
+	{
+		$certsPath = $this->certificatesPath();
 
-        $this->files->ensureDirExists($certsPath, user());
+		$this->files->ensureDirExists($certsPath, user());
 
-        $certs = $this->getCertificates($certsPath);
+		$certs = $this->getCertificates($certsPath);
 
-        return $this->getSites($this->sitesPath(), $certs);
-    }
+		return $this->getSites($this->sitesPath(), $certs);
+	}
 
-    /**
-     * Pretty print out all parked links in Valet.
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function parked()
-    {
-        $certs = $this->getCertificates();
+	/**
+	 * Pretty print out all parked links in Valet.
+	 *
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function parked()
+	{
+		$certs = $this->getCertificates();
 
-        $links = $this->getSites($this->sitesPath(), $certs);
+		$links = $this->getSites($this->sitesPath(), $certs);
 
-        $config = $this->config->read();
-        $parkedLinks = collect();
-        foreach (array_reverse($config['paths']) as $path) {
-            if ($path === $this->sitesPath()) {
-                continue;
-            }
+		$config = $this->config->read();
+		$parkedLinks = collect();
+		foreach (array_reverse($config['paths']) as $path) {
+			if ($path === $this->sitesPath()) {
+				continue;
+			}
 
-            // Only merge on the parked sites that don't interfere with the linked sites
-            $sites = $this->getSites($path, $certs)->filter(function ($site, $key) use ($links) {
-                return ! $links->has($key);
-            });
+			// Only merge on the parked sites that don't interfere with the linked sites
+			$sites = $this->getSites($path, $certs)->filter(function ($site, $key) use ($links) {
+				return !$links->has($key);
+			});
 
-            $parkedLinks = $parkedLinks->merge($sites);
-        }
+			$parkedLinks = $parkedLinks->merge($sites);
+		}
 
-        return $parkedLinks;
-    }
+		return $parkedLinks;
+	}
 
-    /**
-     * Get all sites which are proxies (not Links, and contain proxy_pass directive).
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function proxies()
-    {
-        $dir = $this->nginxPath();
-        $tld = $this->config->read()['tld'];
-        $links = $this->links();
-        $certs = $this->getCertificates();
+	/**
+	 * Get all sites which are proxies (not Links, and contain proxy_pass directive).
+	 *
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function proxies()
+	{
+		$dir = $this->nginxPath();
+		$tld = $this->config->read()['tld'];
+		$links = $this->links();
+		$certs = $this->getCertificates();
 
-        if (! $this->files->exists($dir)) {
-            return collect();
-        }
+		if (!$this->files->exists($dir)) {
+			return collect();
+		}
 
-        $proxies = collect($this->files->scandir($dir))
-        ->filter(function ($site, $key) use ($tld) {
-            // keep sites that match our TLD
-            return ends_with($site, ".$tld.conf");
-        })->map(function ($site, $key) use ($tld) {
-            // remove the TLD suffix for consistency
-            return str_replace(".$tld.conf", '', $site);
-        })->reject(function ($site, $key) use ($links) {
-            return $links->has($site);
-        })->mapWithKeys(function ($site) {
-            $host = $this->getProxyHostForSite($site) ?: '(other)';
+		$proxies = collect($this->files->scandir($dir))
+			->filter(function ($site, $key) use ($tld) {
+				// keep sites that match our TLD
+				return ends_with($site, ".$tld.conf");
+			})->map(function ($site, $key) use ($tld) {
+			// remove the TLD suffix for consistency
+			return str_replace(".$tld.conf", '', $site);
+		})->reject(function ($site, $key) use ($links) {
+			return $links->has($site);
+		})->mapWithKeys(function ($site) {
+			$host = $this->getProxyHostForSite($site) ?: '(other)';
 
-            return [$site => $host];
-        })->reject(function ($host, $site) {
-            // If proxy host is null, it may be just a normal SSL stub, or something else; either way we exclude it from the list
-            return $host === '(other)';
-        })->map(function ($host, $site) use ($certs, $tld) {
-            $secured = $certs->has($site);
-            $url = ($secured ? 'https' : 'http').'://'.$site.'.'.$tld;
+			return [$site => $host];
+		})->reject(function ($host, $site) {
+			// If proxy host is null, it may be just a normal SSL stub, or something else; either way we exclude it from the list
+			return $host === '(other)';
+		})->map(function ($host, $site) use ($certs, $tld) {
+			$secured = $certs->has($site);
+			$url = ($secured ? 'https' : 'http') . '://' . $site . '.' . $tld;
 
-            return [
-                'site' => $site,
-                'secured' => $secured ? ' X' : '',
-                'url' => $url,
-                'path' => $host,
-            ];
-        });
+			return [
+				'site' => $site,
+				'secured' => $secured ? ' X' : '',
+				'url' => $url,
+				'path' => $host,
+			];
+		});
 
-        return $proxies;
-    }
+		return $proxies;
+	}
 
-    /**
-     * Identify whether a site is for a proxy by reading the host name from its config file.
-     *
-     * @param  string  $site  Site name without TLD
-     * @param  string  $configContents  Config file contents
-     * @return string|null
-     */
-    public function getProxyHostForSite($site, $configContents = null)
-    {
-        $siteConf = $configContents ?: $this->getSiteConfigFileContents($site);
+	/**
+	 * Identify whether a site is for a proxy by reading the host name from its config file.
+	 *
+	 * @param  string  $site  Site name without TLD
+	 * @param  string  $configContents  Config file contents
+	 * @return string|null
+	 */
+	public function getProxyHostForSite($site, $configContents = null)
+	{
+		$siteConf = $configContents ?: $this->getSiteConfigFileContents($site);
 
-        if (empty($siteConf)) {
-            return null;
-        }
+		if (empty($siteConf)) {
+			return null;
+		}
 
-        $host = null;
-        if (preg_match('~proxy_pass\s+(?<host>https?://.*)\s*;~', $siteConf, $patterns)) {
-            $host = trim($patterns['host']);
-        }
+		$host = null;
+		if (preg_match('~proxy_pass\s+(?<host>https?://.*)\s*;~', $siteConf, $patterns)) {
+			$host = trim($patterns['host']);
+		}
 
-        return $host;
-    }
+		return $host;
+	}
 
-    public function getSiteConfigFileContents($site, $suffix = null)
-    {
-        $config = $this->config->read();
-        $suffix = $suffix ?: '.'.$config['tld'];
-        $file = str_replace($suffix, '', $site).$suffix;
+	public function getSiteConfigFileContents($site, $suffix = null)
+	{
+		$config = $this->config->read();
+		$suffix = $suffix ?: '.' . $config['tld'];
+		$file = str_replace($suffix, '', $site) . $suffix;
 
-        return $this->files->exists($this->nginxPath($file)) ? $this->files->get($this->nginxPath($file)) : null;
-    }
+		return $this->files->exists($this->nginxPath($file)) ? $this->files->get($this->nginxPath($file)) : null;
+	}
 
-    /**
-     * Get all certificates from config folder.
-     *
-     * @param  string  $path
-     * @return \Illuminate\Support\Collection
-     */
-    public function getCertificates($path = null)
-    {
-        $path = $path ?: $this->certificatesPath();
+	/**
+	 * Get all certificates from config folder.
+	 *
+	 * @param  string  $path
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function getCertificates($path = null)
+	{
+		$path = $path ?: $this->certificatesPath();
 
-        $this->files->ensureDirExists($path, user());
+		$this->files->ensureDirExists($path, user());
 
-        $config = $this->config->read();
+		$config = $this->config->read();
 
-        return collect($this->files->scandir($path))->filter(function ($value, $key) {
-            return ends_with($value, '.crt');
-        })->map(function ($cert) use ($config) {
-            $certWithoutSuffix = substr($cert, 0, -4);
-            $trimToString = '.';
+		return collect($this->files->scandir($path))->filter(function ($value, $key) {
+			return ends_with($value, '.crt');
+		})->map(function ($cert) use ($config) {
+			$certWithoutSuffix = substr($cert, 0, -4);
+			$trimToString = '.';
 
-            // If we have the cert ending in our tld strip that tld specifically
-            // if not then just strip the last segment for  backwards compatibility.
-            if (ends_with($certWithoutSuffix, $config['tld'])) {
-                $trimToString .= $config['tld'];
-            }
+			// If we have the cert ending in our tld strip that tld specifically
+			// if not then just strip the last segment for  backwards compatibility.
+			if (ends_with($certWithoutSuffix, $config['tld'])) {
+				$trimToString .= $config['tld'];
+			}
 
-            return substr($certWithoutSuffix, 0, strrpos($certWithoutSuffix, $trimToString));
-        })->flip();
-    }
+			return substr($certWithoutSuffix, 0, strrpos($certWithoutSuffix, $trimToString));
+		})->flip();
+	}
 
-    /**
-     * @deprecated Use getSites instead which works for both normal and symlinked paths.
-     *
-     * @param  string  $path
-     * @param  \Illuminate\Support\Collection  $certs
-     * @return \Illuminate\Support\Collection
-     */
-    public function getLinks($path, $certs)
-    {
-        return $this->getSites($path, $certs);
-    }
+	/**
+	 * @deprecated Use getSites instead which works for both normal and symlinked paths.
+	 *
+	 * @param  string  $path
+	 * @param  \Illuminate\Support\Collection  $certs
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function getLinks($path, $certs)
+	{
+		return $this->getSites($path, $certs);
+	}
 
-    /**
-     * Get list of sites and return them formatted
-     * Will work for symlink and normal site paths.
-     *
-     * @param  string  $path
-     * @param  \Illuminate\Support\Collection  $certs
-     * @return \Illuminate\Support\Collection
-     */
-    public function getSites($path, $certs)
-    {
-        $config = $this->config->read();
+	/**
+	 * Determines which PHP version the current working directory is using.
+	 *
+	 * @param  string  $cwd
+	 * @return Array [ "site" => [sitename], "php" => [PHP version] ]
+	 */
+	public function whichPhp($cwd)
+	{
+		$currentSite = $this->parked()->filter(function ($site, $key) use ($cwd) {
+			if ($key === $cwd)
+				return $site;
+		});
 
-        $this->files->ensureDirExists($path, user());
+		foreach ($currentSite as $value) {
+			foreach ($value as $key => $val) {
+				$site = $cwd;
+				$site .= !empty($value["alias"]) ? " (alias: {$value["alias"]})" : "";
 
-        return collect($this->files->scandir($path))->mapWithKeys(function ($site) use ($path) {
-            $sitePath = $path.'/'.$site;
+				if ($key === "php") {
+					return [
+						"site" => $site,
+						"php" => $val
+					];
+				}
+			}
+		}
+	}
 
-            if ($this->files->isLink($sitePath)) {
-                $realPath = $this->files->readLink($sitePath);
-            } else {
-                $realPath = $this->files->realpath($sitePath);
-            }
+	/**
+	 * Create a site object (aka associative array) using Laravel Collection with site details, like name, php version, etc.
+	 * 
+	 * @param string $path Either the path to the parked sites directory or the symbolic link sites directory.
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function createSiteObject($path)
+	{
+		return collect($this->files->scandir($path))->mapWithKeys(function ($site) use ($path) {
+			$sitePath = $path . '/' . $site;
 
-            return [$site => $realPath];
-        })->filter(function ($path) {
-            return $this->files->isDir($path);
-        })->map(function ($path, $site) use ($certs, $config) {
-            $secured = $certs->has($site);
-            $url = ($secured ? 'https' : 'http').'://'.$site.'.'.$config['tld'];
-            $phpVersion = $this->customPhpVersion($site.'.'.$config['tld']);
+			if ($this->files->isLink($sitePath)) {
+				$realPath = $this->files->readLink($sitePath);
+			} else {
+				$realPath = $this->files->realpath($sitePath);
+			}
+
+			return [$site => $realPath];
+		})->filter(function ($path) {
+			return $this->files->isDir($path);
+		});
+	}
+
+	/**
+	 * Get list of sites and return them formatted
+	 * Will work for symlink and normal site paths.
+	 *
+	 * @param  string  $path
+	 * @param  \Illuminate\Support\Collection  $certs
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function getSites($path, $certs)
+	{
+		$config = $this->config->read();
+
+		$this->files->ensureDirExists($path, user());
+
+		$links = $this->createSiteObject($this->sitesPath())->flatMap(function ($item, $key) {
+			return ["site" => $key, "path" => $item];
+		});
+
+		$parked = $this->createSiteObject($path);
+
+
+		return $parked->map(function ($path, $site) use ($certs, $config, $links) {
+
+			$alias = ""; // Default variable string.
+			$secured = $certs->has($site);
+			$url = ($secured ? 'https' : 'http') . '://' . $site . '.' . $config['tld'];
+			$aliasUrl = ""; // Default variable string.
+
+
+			$phpVersion = $this->customPhpVersion($site . '.' . $config['tld']);
 			$defaultVersion = $this->config->get('default_php');
 
-            return [
-                'site' => $site,
-                'secured' => $secured ? ' X' : '',
-                'php' => $phpVersion ? "<info>$phpVersion (isolated)</info>" : "$defaultVersion (default)",
-                'url' => $url,
-                'path' => $path,
-            ];
-        });
-    }
-
-    /**
-     * Unlink the given symbolic link.
-     *
-     * @param  string  $name
-     * @return void
-     */
-    public function unlink($name)
-    {
-        $name = $this->getRealSiteName($name);
-
-        if ($this->files->exists($path = $this->sitesPath($name))) {
-            $this->files->unlink($path);
-        }
-
-        return $name;
-    }
-
-    /**
-     * Remove all broken symbolic links.
-     *
-     * @return void
-     */
-    public function pruneLinks()
-    {
-        $this->files->ensureDirExists($this->sitesPath(), user());
-
-        $this->files->removeBrokenLinksAt($this->sitesPath());
-    }
-
-    /**
-     * Resecure all currently secured sites with a fresh tld.
-     *
-     * @param  string  $oldTld
-     * @param  string  $tld
-     * @return void
-     */
-    public function resecureForNewTld($oldTld, $tld)
-    {
-        if (! $this->files->exists($this->certificatesPath())) {
-            return;
-        }
-
-        $secured = $this->secured();
-
-        foreach ($secured as $url) {
-            $newUrl = str_replace('.'.$oldTld, '.'.$tld, $url);
-            $siteConf = $this->getSiteConfigFileContents($url, '.'.$oldTld);
-
-            if (! empty($siteConf) && strpos($siteConf, '# valet stub: proxy.valet.conf') === 0) {
-                // proxy config
-                $this->unsecure($url);
-                $this->secure($newUrl, $this->replaceOldDomainWithNew($siteConf, $url, $newUrl));
-            } else {
-                // normal config
-                $this->unsecure($url);
-                $this->secure($newUrl);
-            }
-        }
-    }
-
-    /**
-     * Parse Nginx site config file contents to swap old domain to new.
-     *
-     * @param  string  $siteConf  Nginx site config content
-     * @param  string  $old  Old domain
-     * @param  string  $new  New domain
-     * @return string
-     */
-    public function replaceOldDomainWithNew($siteConf, $old, $new)
-    {
-        $lookups = [];
-        $lookups[] = '~server_name .*;~';
-        $lookups[] = '~error_log .*;~';
-        $lookups[] = '~ssl_certificate_key .*;~';
-        $lookups[] = '~ssl_certificate .*;~';
-
-        foreach ($lookups as $lookup) {
-            preg_match($lookup, $siteConf, $matches);
-            foreach ($matches as $match) {
-                $replaced = str_replace($old, $new, $match);
-                $siteConf = str_replace($match, $replaced, $siteConf);
-            }
-        }
-
-        return $siteConf;
-    }
-
-    /**
-     * Get all of the URLs that are currently secured.
-     *
-     * @return array
-     */
-    public function publishParkedNginxConf($parkedPath)
-    {
-        $parked = $this->parked();
-
-        // TODO
-    }
-
-    /**
-     * Get the site URL from a directory if it's a valid Valet site.
-     *
-     * @param  string  $directory
-     * @return string|false
-     */
-    public function usePhp($phpVersion, $directory)
-    {
-        $site = $this->getSiteUrl($directory);
-
-        if (! $site) {
-            throw new DomainException("The {$directory} site could not be found in Valet's site list.");
-        }
-
-        // Remove isolation for this site
-        if ($phpVersion == 'default') {
-            // Example output: "7.4"
-            $oldCustomPhpVersion = $this->customPhpVersion($site);
-            $this->removeIsolation($site);
-            \Nginx::restart();
-            info("The site [$site] is now using the default PHP version.");
-
-            return;
-        }
-
-        $php = $this->config->getPhpByVersion($phpVersion);
-
-        if (empty($php)) {
-            warning("Cannot find PHP [$phpVersion] in the list.");
-        }
-
-        $this->installSiteConfig($site, $php['version']);
-
-        info('Restarting Nginx...');
-        \Nginx::stop();
-        \Nginx::restart();
-        info("The site [$site] is now using $phpVersion.");
-    }
-
-    /**
-     * Get the site URL from a directory if it's a valid Valet site.
-     *
-     * @param  string  $directory
-     * @return string|false
-     */
-    public function getSiteUrl($directory)
-    {
-        $tld = $this->config->read()['tld'];
-
-        // Allow user to use dot as current dir's site `--site=.`
-        if ($directory == '.' || $directory == './') {
-            $directory = $this->host(getcwd());
-        }
-
-        // Remove .tld from sitename if it was provided
-        $directory = str_replace('.'.$tld, '', $directory);
-
-        if (! $this->parked()->merge($this->links())->where('site', $directory)->count() > 0) {
-            // Invalid directory provided
-            warning('Invalid site or directory given');
-
-            return false;
-        }
-
-        return $directory.'.'.$tld;
-    }
-
-    /**
-     * Extract PHP version of exising nginx conifg.
-     *
-     * @param  string  $url
-     * @return string|void
-     */
-    public function customPhpVersion($url)
-    {
-        if ($this->files->exists($this->nginxPath($url))) {
-            $siteConf = $this->files->get($this->nginxPath($url));
-
-            if (starts_with($siteConf, '# Valet isolated PHP version')) {
-                $firstLine = explode(PHP_EOL, $siteConf)[0];
-
-                return trim(str_replace('# Valet isolated PHP version : ', '', $firstLine));
-            }
-        }
-    }
-
-    /**
-     * Get all of the URLs that are currently secured.
-     *
-     * @return array
-     */
-    public function secured()
-    {
-        return collect($this->files->scandir($this->certificatesPath()))
-                    ->map(function ($file) {
-                        return str_replace(['.key', '.csr', '.crt', '.conf'], '', $file);
-                    })->unique()->values()->all();
-    }
-
-    /**
-     * Secure the given host with TLS.
-     *
-     * @param  string  $url
-     * @param  string  $siteConf  pregenerated Nginx config file contents
-     * @return void
-     */
-    public function secure($url, $siteConf = null)
-    {
-        // Extract in order to later preserve custom PHP version config when securing
-        $phpVersion = $this->customPhpVersion($url);
-        $this->unsecure($url);
-
-        $this->files->ensureDirExists($this->certificatesPath(), user());
-
-        $this->files->ensureDirExists($this->nginxPath(), user());
-
-        $this->createCertificate($url);
-
-        $siteConf = $this->buildSecureNginxServer($url, $siteConf);
-
-        // If the user had isolated the PHP version for this site, swap out the PHP version
-        if ($phpVersion) {
-            $php = $this->config->getPhpByVersion($phpVersion);
-            $siteConf = $this->replacePhpVersionInSiteConf($siteConf, $php['port'], $phpVersion);
-        }
-
-        $this->files->putAsUser(
-            $this->nginxPath($url), $this->buildSecureNginxServer($url, $siteConf)
-        );
-    }
-
-    /**
-     * Get the port of the given host.
-     *
-     * @param  string  $url
-     * @return int
-     */
-    public function port(string $url): int
-    {
-        if ($this->files->exists($path = $this->nginxPath($url))) {
-            if (strpos($this->files->get($path), '443') !== false) {
-                return 443;
-            }
-        }
-
-        return 80;
-    }
-
-    /**
-     * Create and trust a certificate for the given URL.
-     *
-     * @param  string  $url
-     * @return void
-     */
-    public function createCertificate($url)
-    {
-        $keyPath = $this->certificatesPath($url, 'key');
-        $csrPath = $this->certificatesPath($url, 'csr');
-        $crtPath = $this->certificatesPath($url, 'crt');
-
-        $this->createPrivateKey($keyPath);
-        $this->createSigningRequest($url, $keyPath, $csrPath);
-        $this->createSignedCertificate($keyPath, $csrPath, $crtPath);
-
-        $this->trustCertificate($crtPath);
-    }
-
-    /**
-     * Create the private key for the TLS certificate.
-     *
-     * @param  string  $keyPath
-     * @return void
-     */
-    public function createPrivateKey(string $keyPath)
-    {
-        /** @var \phpseclib3\Crypt\RSA\PrivateKey */
-        $key = RSA::createKey();
-
-        $this->files->putAsUser($keyPath, $key->toString('PKCS1'));
-    }
-
-    /**
-     * Create the signing request for the TLS certificate.
-     *
-     * @param  string  $url
-     * @param  string  $keyPath
-     * @param  string  $csrPath
-     * @return void
-     */
-    public function createSigningRequest(string $url, string $keyPath, string $csrPath)
-    {
-        /** @var \phpseclib3\Crypt\RSA\PrivateKey */
-        $privKey = RSA::load($this->files->get($keyPath));
-
-        $x509 = new X509();
-        $x509->setPrivateKey($privKey);
-        $x509->setDNProp('commonname', $url);
-
-        $x509->loadCSR($x509->saveCSR($x509->signCSR()));
-
-        $x509->setExtension('id-ce-subjectAltName', [
-            ['dNSName' => $url],
-            ['dNSName' => "*.$url"],
-        ]);
-
-        $x509->setExtension('id-ce-keyUsage', [
-            'digitalSignature',
-            'nonRepudiation',
-            'keyEncipherment',
-        ]);
-
-        $csr = $x509->saveCSR($x509->signCSR());
-
-        $this->files->putAsUser($csrPath, $csr);
-    }
-
-    /**
-     * Create the signed TLS certificate.
-     *
-     * @param  string  $keyPath
-     * @param  string  $csrPath
-     * @param  string  $crtPath
-     * @return void
-     */
-    public function createSignedCertificate(string $keyPath, string $csrPath, string $crtPath)
-    {
-        /** @var \phpseclib3\Crypt\RSA\PrivateKey */
-        $privKey = RSA::load($this->files->get($keyPath));
-        $privKey = $privKey->withPadding(RSA::SIGNATURE_PKCS1);
-
-        $subject = new X509();
-        $subject->loadCSR($this->files->get($csrPath));
-        $subject->setPublicKey($privKey->getPublicKey());
-
-        $issuer = new X509();
-        $issuer->setPrivateKey($privKey);
-        $issuer->setDN($subject->getDN());
-
-        $x509 = new X509();
-        $x509->makeCA();
-        $x509->setStartDate('-1 day');
-
-        $result = $x509->sign($issuer, $subject);
-        $certificate = $x509->saveX509($result);
-
-        $this->files->putAsUser($crtPath, $certificate);
-    }
-
-    /**
-     * Trust the given certificate file in the Windows Certmgr.
-     *
-     * @param  string  $crtPath
-     * @return void
-     */
-    public function trustCertificate(string $crtPath)
-    {
-        $this->cli->runOrExit(sprintf('cmd "/C certutil -addstore "Root" "%s""', $crtPath), function ($code, $output) {
-            error("Failed to trust certificate: $output");
-        });
-    }
-
-    /**
-     * Build the Nginx server configuration for the given Valet site.
-     *
-     * @param  string  $valetSite
-     * @param  string  $phpVersion
-     * @return string
-     */
-    public function installSiteConfig($valetSite, $phpVersion)
-    {
-        $phpVersion = $phpVersion ? $phpVersion : $this->config->get('default_php');
-
-        $php = $this->config->getPhpByVersion($phpVersion);
-
-        if (empty($php)) {
-            warning("Cannot find PHP [$phpVersion] in the list.");
-
-            return;
-        }
-
-        if ($this->files->exists($this->nginxPath($valetSite))) {
-            $siteConf = $this->files->get($this->nginxPath($valetSite));
-        } else {
-            $siteConf = $this->files->get(__DIR__.'/../stubs/unsecure.valet.conf');
-            $siteConf = str_replace(
-                ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'VALET_SITE', 'HOME_PATH'],
-                [$this->valetHomePath(), VALET_SERVER_PATH, VALET_STATIC_PREFIX, $valetSite, $_SERVER['HOME']],
-                $siteConf
-            );
-        }
-
-        $siteConf = $this->replacePhpVersionInSiteConf($siteConf, $php['port'], $php['version']);
-
-        $this->files->putAsUser($this->nginxPath($valetSite), $siteConf);
-    }
-
-    /**
-     * Remove PHP Version isolation from a specific site.
-     *
-     * @param  string  $valetSite
-     * @return void
-     */
-    public function removeIsolation($valetSite)
-    {
-        $existingSiteConf = $this->getSiteConfigFileContents($valetSite);
-
-        if (empty($existingSiteConf)) {
-            $siteConf = $this->buildSecureNginxServer($valetSite);
-        }
-
-        $siteConf = $this->replacePhpVersionInSiteConf($valetSite, '$valet_php_port');
-
-        // If a site has an SSL certificate, we need to keep its custom config file
-        if ($this->files->exists($this->certificatesPath($valetSite, 'crt'))) {
-            $this->files->putAsUser($this->nginxPath($valetSite), $siteConf);
-        } else {
-            if ($existingSiteConf) {
-                $this->files->putAsUser($this->nginxPath($valetSite), $siteConf);
-            }
-        }
-    }
-
-    /**
-     * Build the TLS secured Nginx server for the given URL.
-     *
-     * @param  string  $url
-     * @param  string  $siteConf  (optional) Nginx site config file content
-     * @return string
-     */
-    public function buildSecureNginxServer($url, $siteConf = null)
-    {
-        if ($siteConf === null) {
-            $siteConf = $this->files->get(__DIR__.'/../stubs/secure.valet.conf');
-        }
-
-        $path = $this->certificatesPath();
-
-//        , 'VALET_PHP_PORT', 'VALET_ISOLATED_PHP_VERSION'
+			return [
+				'site' => $site,
+				'secured' => $secured ? ' X' : '',
+				'php' => $phpVersion ? "<info>$phpVersion (isolated)</info>" : "$defaultVersion (default)",
+				'url' => $url,
+				'path' => $path,
+			];
+		});
+	}
+
+	/**
+	 * Unlink the given symbolic link.
+	 *
+	 * @param  string  $name
+	 * @return void
+	 */
+	public function unlink($name)
+	{
+		$name = $this->getRealSiteName($name);
+
+		if ($this->files->exists($path = $this->sitesPath($name))) {
+			$this->files->unlink($path);
+		}
+
+		return $name;
+	}
+
+	/**
+	 * Remove all broken symbolic links.
+	 *
+	 * @return void
+	 */
+	public function pruneLinks()
+	{
+		$this->files->ensureDirExists($this->sitesPath(), user());
+
+		$this->files->removeBrokenLinksAt($this->sitesPath());
+	}
+
+	/**
+	 * Resecure all currently secured sites with a fresh tld.
+	 *
+	 * @param  string  $oldTld
+	 * @param  string  $tld
+	 * @return void
+	 */
+	public function resecureForNewTld($oldTld, $tld)
+	{
+		if (!$this->files->exists($this->certificatesPath())) {
+			return;
+		}
+
+		$secured = $this->secured();
+
+		foreach ($secured as $url) {
+			$newUrl = str_replace('.' . $oldTld, '.' . $tld, $url);
+			$siteConf = $this->getSiteConfigFileContents($url, '.' . $oldTld);
+
+			if (!empty($siteConf) && strpos($siteConf, '# valet stub: proxy.valet.conf') === 0) {
+				// proxy config
+				$this->unsecure($url);
+				$this->secure($newUrl, $this->replaceOldDomainWithNew($siteConf, $url, $newUrl));
+			} else {
+				// normal config
+				$this->unsecure($url);
+				$this->secure($newUrl);
+			}
+		}
+	}
+
+	/**
+	 * Parse Nginx site config file contents to swap old domain to new.
+	 *
+	 * @param  string  $siteConf  Nginx site config content
+	 * @param  string  $old  Old domain
+	 * @param  string  $new  New domain
+	 * @return string
+	 */
+	public function replaceOldDomainWithNew($siteConf, $old, $new)
+	{
+		$lookups = [];
+		$lookups[] = '~server_name .*;~';
+		$lookups[] = '~error_log .*;~';
+		$lookups[] = '~ssl_certificate_key .*;~';
+		$lookups[] = '~ssl_certificate .*;~';
+
+		foreach ($lookups as $lookup) {
+			preg_match($lookup, $siteConf, $matches);
+			foreach ($matches as $match) {
+				$replaced = str_replace($old, $new, $match);
+				$siteConf = str_replace($match, $replaced, $siteConf);
+			}
+		}
+
+		return $siteConf;
+	}
+
+	/**
+	 * Get all of the URLs that are currently secured.
+	 *
+	 * @return array
+	 */
+	public function publishParkedNginxConf($parkedPath)
+	{
+		$parked = $this->parked();
+
+		// TODO
+	}
+
+	/**
+	 * Get the site URL from a directory if it's a valid Valet site.
+	 *
+	 * @param  string  $directory
+	 * @return string|false
+	 */
+	public function usePhp($phpVersion, $directory)
+	{
+		$site = $this->getSiteUrl($directory);
+
+		if (!$site) {
+			throw new DomainException("The {$directory} site could not be found in Valet's site list.");
+		}
+
+		// Remove isolation for this site
+		if ($phpVersion == 'default') {
+			// Example output: "7.4"
+			$oldCustomPhpVersion = $this->customPhpVersion($site);
+			$this->removeIsolation($site);
+			\Nginx::restart();
+			info("The site [$site] is now using the default PHP version.");
+
+			return;
+		}
+
+		$php = $this->config->getPhpByVersion($phpVersion);
+
+		if (empty($php)) {
+			warning("Cannot find PHP [$phpVersion] in the list.");
+		}
+
+		$this->installSiteConfig($site, $php['version']);
+
+		info('Restarting Nginx...');
+		\Nginx::stop();
+		\Nginx::restart();
+		info("The site [$site] is now using $phpVersion.");
+	}
+
+	/**
+	 * Get the site URL from a directory if it's a valid Valet site.
+	 *
+	 * @param  string  $directory
+	 * @return string|false
+	 */
+	public function getSiteUrl($directory)
+	{
+		$tld = $this->config->read()['tld'];
+
+		// Allow user to use dot as current dir's site `--site=.`
+		if ($directory == '.' || $directory == './') {
+			$directory = $this->host(getcwd());
+		}
+
+		// Remove .tld from sitename if it was provided
+		$directory = str_replace('.' . $tld, '', $directory);
+
+		if (!$this->parked()->merge($this->links())->where('site', $directory)->count() > 0) {
+			// Invalid directory provided
+			warning('Invalid site or directory given');
+
+			return false;
+		}
+
+		return $directory . '.' . $tld;
+	}
+
+	/**
+	 * Extract PHP version of exising nginx conifg.
+	 *
+	 * @param  string  $url
+	 * @return string|void
+	 */
+	public function customPhpVersion($url)
+	{
+		if ($this->files->exists($this->nginxPath($url))) {
+			$siteConf = $this->files->get($this->nginxPath($url));
+
+			if (starts_with($siteConf, '# Valet isolated PHP version')) {
+				$firstLine = explode(PHP_EOL, $siteConf)[0];
+
+				return trim(str_replace('# Valet isolated PHP version : ', '', $firstLine));
+			}
+		}
+	}
+
+	/**
+	 * Get all of the URLs that are currently secured.
+	 *
+	 * @return array
+	 */
+	public function secured()
+	{
+		return collect($this->files->scandir($this->certificatesPath()))
+			->map(function ($file) {
+				return str_replace(['.key', '.csr', '.crt', '.conf'], '', $file);
+			})->unique()->values()->all();
+	}
+
+	/**
+	 * Secure the given host with TLS.
+	 *
+	 * @param  string  $url
+	 * @param  string  $siteConf  pregenerated Nginx config file contents
+	 * @return void
+	 */
+	public function secure($url, $siteConf = null)
+	{
+		// Extract in order to later preserve custom PHP version config when securing
+		$phpVersion = $this->customPhpVersion($url);
+		$this->unsecure($url);
+
+		$this->files->ensureDirExists($this->certificatesPath(), user());
+
+		$this->files->ensureDirExists($this->nginxPath(), user());
+
+		$this->createCertificate($url);
+
+		$siteConf = $this->buildSecureNginxServer($url, $siteConf);
+
+		// If the user had isolated the PHP version for this site, swap out the PHP version
+		if ($phpVersion) {
+			$php = $this->config->getPhpByVersion($phpVersion);
+			$siteConf = $this->replacePhpVersionInSiteConf($siteConf, $php['port'], $phpVersion);
+		}
+
+		$this->files->putAsUser(
+			$this->nginxPath($url), $this->buildSecureNginxServer($url, $siteConf)
+		);
+	}
+
+	/**
+	 * Get the port of the given host.
+	 *
+	 * @param  string  $url
+	 * @return int
+	 */
+	public function port(string $url): int
+	{
+		if ($this->files->exists($path = $this->nginxPath($url))) {
+			if (strpos($this->files->get($path), '443') !== false) {
+				return 443;
+			}
+		}
+
+		return 80;
+	}
+
+	/**
+	 * Create and trust a certificate for the given URL.
+	 *
+	 * @param  string  $url
+	 * @return void
+	 */
+	public function createCertificate($url)
+	{
+		$keyPath = $this->certificatesPath($url, 'key');
+		$csrPath = $this->certificatesPath($url, 'csr');
+		$crtPath = $this->certificatesPath($url, 'crt');
+
+		$this->createPrivateKey($keyPath);
+		$this->createSigningRequest($url, $keyPath, $csrPath);
+		$this->createSignedCertificate($keyPath, $csrPath, $crtPath);
+
+		$this->trustCertificate($crtPath);
+	}
+
+	/**
+	 * Create the private key for the TLS certificate.
+	 *
+	 * @param  string  $keyPath
+	 * @return void
+	 */
+	public function createPrivateKey(string $keyPath)
+	{
+		/** @var \phpseclib3\Crypt\RSA\PrivateKey */
+		$key = RSA::createKey();
+
+		$this->files->putAsUser($keyPath, $key->toString('PKCS1'));
+	}
+
+	/**
+	 * Create the signing request for the TLS certificate.
+	 *
+	 * @param  string  $url
+	 * @param  string  $keyPath
+	 * @param  string  $csrPath
+	 * @return void
+	 */
+	public function createSigningRequest(string $url, string $keyPath, string $csrPath)
+	{
+		/** @var \phpseclib3\Crypt\RSA\PrivateKey */
+		$privKey = RSA::load($this->files->get($keyPath));
+
+		$x509 = new X509();
+		$x509->setPrivateKey($privKey);
+		$x509->setDNProp('commonname', $url);
+
+		$x509->loadCSR($x509->saveCSR($x509->signCSR()));
+
+		$x509->setExtension('id-ce-subjectAltName', [
+			['dNSName' => $url],
+			['dNSName' => "*.$url"],
+		]);
+
+		$x509->setExtension('id-ce-keyUsage', [
+			'digitalSignature',
+			'nonRepudiation',
+			'keyEncipherment',
+		]);
+
+		$csr = $x509->saveCSR($x509->signCSR());
+
+		$this->files->putAsUser($csrPath, $csr);
+	}
+
+	/**
+	 * Create the signed TLS certificate.
+	 *
+	 * @param  string  $keyPath
+	 * @param  string  $csrPath
+	 * @param  string  $crtPath
+	 * @return void
+	 */
+	public function createSignedCertificate(string $keyPath, string $csrPath, string $crtPath)
+	{
+		/** @var \phpseclib3\Crypt\RSA\PrivateKey */
+		$privKey = RSA::load($this->files->get($keyPath));
+		$privKey = $privKey->withPadding(RSA::SIGNATURE_PKCS1);
+
+		$subject = new X509();
+		$subject->loadCSR($this->files->get($csrPath));
+		$subject->setPublicKey($privKey->getPublicKey());
+
+		$issuer = new X509();
+		$issuer->setPrivateKey($privKey);
+		$issuer->setDN($subject->getDN());
+
+		$x509 = new X509();
+		$x509->makeCA();
+		$x509->setStartDate('-1 day');
+
+		$result = $x509->sign($issuer, $subject);
+		$certificate = $x509->saveX509($result);
+
+		$this->files->putAsUser($crtPath, $certificate);
+	}
+
+	/**
+	 * Trust the given certificate file in the Windows Certmgr.
+	 *
+	 * @param  string  $crtPath
+	 * @return void
+	 */
+	public function trustCertificate(string $crtPath)
+	{
+		$this->cli->runOrExit(sprintf('cmd "/C certutil -addstore "Root" "%s""', $crtPath), function ($code, $output) {
+			error("Failed to trust certificate: $output");
+		});
+	}
+
+	/**
+	 * Build the Nginx server configuration for the given Valet site.
+	 *
+	 * @param  string  $valetSite
+	 * @param  string  $phpVersion
+	 * @return string
+	 */
+	public function installSiteConfig($valetSite, $phpVersion)
+	{
+		$phpVersion = $phpVersion ? $phpVersion : $this->config->get('default_php');
+
+		$php = $this->config->getPhpByVersion($phpVersion);
+
+		if (empty($php)) {
+			warning("Cannot find PHP [$phpVersion] in the list.");
+
+			return;
+		}
+
+		if ($this->files->exists($this->nginxPath($valetSite))) {
+			$siteConf = $this->files->get($this->nginxPath($valetSite));
+		} else {
+			$siteConf = $this->files->get(__DIR__ . '/../stubs/unsecure.valet.conf');
+			$siteConf = str_replace(
+				['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'VALET_SITE', 'HOME_PATH'],
+				[$this->valetHomePath(), VALET_SERVER_PATH, VALET_STATIC_PREFIX, $valetSite, $_SERVER['HOME']],
+				$siteConf
+			);
+		}
+
+		$siteConf = $this->replacePhpVersionInSiteConf($siteConf, $php['port'], $php['version']);
+
+		$this->files->putAsUser($this->nginxPath($valetSite), $siteConf);
+	}
+
+	/**
+	 * Remove PHP Version isolation from a specific site.
+	 *
+	 * @param  string  $valetSite
+	 * @return void
+	 */
+	public function removeIsolation($valetSite)
+	{
+		$existingSiteConf = $this->getSiteConfigFileContents($valetSite);
+
+		if (empty($existingSiteConf)) {
+			$siteConf = $this->buildSecureNginxServer($valetSite);
+		}
+
+		$siteConf = $this->replacePhpVersionInSiteConf($valetSite, '$valet_php_port');
+
+		// If a site has an SSL certificate, we need to keep its custom config file
+		if ($this->files->exists($this->certificatesPath($valetSite, 'crt'))) {
+			$this->files->putAsUser($this->nginxPath($valetSite), $siteConf);
+		} else {
+			if ($existingSiteConf) {
+				$this->files->putAsUser($this->nginxPath($valetSite), $siteConf);
+			}
+		}
+	}
+
+	/**
+	 * Build the TLS secured Nginx server for the given URL.
+	 *
+	 * @param  string  $url
+	 * @param  string  $siteConf  (optional) Nginx site config file content
+	 * @return string
+	 */
+	public function buildSecureNginxServer($url, $siteConf = null)
+	{
+		if ($siteConf === null) {
+			$siteConf = $this->files->get(__DIR__ . '/../stubs/secure.valet.conf');
+		}
+
+		$path = $this->certificatesPath();
+
+		//        , 'VALET_PHP_PORT', 'VALET_ISOLATED_PHP_VERSION'
 //    , $php['port'], $php['version']
 
-        return str_replace(
-            ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'VALET_SITE', 'VALET_CERT', 'VALET_KEY', 'HOME_PATH'],
-            [$this->valetHomePath(), VALET_SERVER_PATH, VALET_STATIC_PREFIX, $url, $path.'/'.$url.'.crt', $path.'/'.$url.'.key', $_SERVER['HOME']],
-            $siteConf
-        );
-    }
+		return str_replace(
+			['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'VALET_SITE', 'VALET_CERT', 'VALET_KEY', 'HOME_PATH'],
+			[$this->valetHomePath(), VALET_SERVER_PATH, VALET_STATIC_PREFIX, $url, $path . '/' . $url . '.crt', $path . '/' . $url . '.key', $_SERVER['HOME']],
+			$siteConf
+		);
+	}
 
-    /**
-     * Replace .sock file in an Nginx site configuration file contents.
-     *
-     * @param  string  $siteConf
-     * @param  string  $phpPort
-     */
-    public function replacePhpVersionInSiteConf($siteConf, $phpPort, $phpVersion = null)
-    {
-        $siteConf = preg_replace('/127.0.0.1:[0-9]*;/', "127.0.0.1:{$phpPort};", $siteConf);
-        $siteConf = str_replace('127.0.0.1:$valet_php_port;', "127.0.0.1:{$phpPort};", $siteConf);
+	/**
+	 * Replace .sock file in an Nginx site configuration file contents.
+	 *
+	 * @param  string  $siteConf
+	 * @param  string  $phpPort
+	 */
+	public function replacePhpVersionInSiteConf($siteConf, $phpPort, $phpVersion = null)
+	{
+		$siteConf = preg_replace('/127.0.0.1:[0-9]*;/', "127.0.0.1:{$phpPort};", $siteConf);
+		$siteConf = str_replace('127.0.0.1:$valet_php_port;', "127.0.0.1:{$phpPort};", $siteConf);
 
-        // Remove `Valet isolated PHP version` line from config
-        $siteConf = preg_replace('/# Valet isolated PHP version.*\n/', '', $siteConf);
+		// Remove `Valet isolated PHP version` line from config
+		$siteConf = preg_replace('/# Valet isolated PHP version.*\n/', '', $siteConf);
 
-        if ($phpVersion) {
-            $siteConf = '# Valet isolated PHP version : '.$phpVersion.PHP_EOL.$siteConf;
-        }
+		if ($phpVersion) {
+			$siteConf = '# Valet isolated PHP version : ' . $phpVersion . PHP_EOL . $siteConf;
+		}
 
-        return $siteConf;
-    }
+		return $siteConf;
+	}
 
-    /**
-     * Unsecure the given URL so that it will use HTTP again.
-     *
-     * @param  string  $url
-     * @return void
-     */
-    public function unsecure($url)
-    {
-        // Extract in order to later preserve custom PHP version config when unsecuring. Example output: "8.1.2"
-        $phpVersion = $this->customPhpVersion($url);
+	/**
+	 * Unsecure the given URL so that it will use HTTP again.
+	 *
+	 * @param  string  $url
+	 * @return void
+	 */
+	public function unsecure($url)
+	{
+		// Extract in order to later preserve custom PHP version config when unsecuring. Example output: "8.1.2"
+		$phpVersion = $this->customPhpVersion($url);
 
-        if ($this->files->exists($this->certificatesPath($url, 'crt'))) {
-            $this->files->unlink($this->nginxPath($url));
+		if ($this->files->exists($this->certificatesPath($url, 'crt'))) {
+			$this->files->unlink($this->nginxPath($url));
 
-            $this->files->unlink($this->certificatesPath($url, 'key'));
-            $this->files->unlink($this->certificatesPath($url, 'csr'));
-            $this->files->unlink($this->certificatesPath($url, 'crt'));
-        }
+			$this->files->unlink($this->certificatesPath($url, 'key'));
+			$this->files->unlink($this->certificatesPath($url, 'csr'));
+			$this->files->unlink($this->certificatesPath($url, 'crt'));
+		}
 
-        $this->cli->run(sprintf('cmd "/C certutil -delstore "Root" "%s""', $url));
+		$this->cli->run(sprintf('cmd "/C certutil -delstore "Root" "%s""', $url));
 
-        // If the user had isolated the PHP version for this site, swap out .sock file
-        if ($phpVersion) {
-            $this->installSiteConfig($url, $phpVersion);
-        }
-    }
+		// If the user had isolated the PHP version for this site, swap out .sock file
+		if ($phpVersion) {
+			$this->installSiteConfig($url, $phpVersion);
+		}
+	}
 
-    public function unsecureAll()
-    {
-        $tld = $this->config->read()['tld'];
+	public function unsecureAll()
+	{
+		$tld = $this->config->read()['tld'];
 
-        $secured = $this->parked()
-            ->merge($this->links())
-            ->sort()
-            ->where('secured', ' X');
+		$secured = $this->parked()
+			->merge($this->links())
+			->sort()
+			->where('secured', ' X');
 
-        if ($secured->count() === 0) {
-            return info('No sites to unsecure. You may list all servable sites or links by running <comment>valet parked</comment> or <comment>valet links</comment>.');
-        }
+		if ($secured->count() === 0) {
+			return info('No sites to unsecure. You may list all servable sites or links by running <comment>valet parked</comment> or <comment>valet links</comment>.');
+		}
 
-        info('Attempting to unsecure the following sites:');
-        table(['Site', 'SSL', 'URL', 'Path'], $secured->toArray());
+		info('Attempting to unsecure the following sites:');
+		table(['Site', 'SSL', 'URL', 'Path'], $secured->toArray());
 
-        foreach ($secured->pluck('site') as $url) {
-            $this->unsecure($url.'.'.$tld);
-        }
+		foreach ($secured->pluck('site') as $url) {
+			$this->unsecure($url . '.' . $tld);
+		}
 
-        $remaining = $this->parked()
-            ->merge($this->links())
-            ->sort()
-            ->where('secured', ' X');
-        if ($remaining->count() > 0) {
-            warning('We were not succesful in unsecuring the following sites:');
-            table(['Site', 'SSL', 'URL', 'Path'], $remaining->toArray());
-        }
-        info('unsecure --all was successful.');
-    }
+		$remaining = $this->parked()
+			->merge($this->links())
+			->sort()
+			->where('secured', ' X');
+		if ($remaining->count() > 0) {
+			warning('We were not succesful in unsecuring the following sites:');
+			table(['Site', 'SSL', 'URL', 'Path'], $remaining->toArray());
+		}
+		info('unsecure --all was successful.');
+	}
 
-    /**
-     * Untrust all certificates.
-     *
-     * @return void
-     */
-    public function untrustCertificates()
-    {
-        $secured = $this->parked()
-            ->merge($this->links())
-            ->sort()
-            ->where('secured', ' X');
+	/**
+	 * Untrust all certificates.
+	 *
+	 * @return void
+	 */
+	public function untrustCertificates()
+	{
+		$secured = $this->parked()
+			->merge($this->links())
+			->sort()
+			->where('secured', ' X');
 
-        if ($secured->isEmpty()) {
-            return;
-        }
+		if ($secured->isEmpty()) {
+			return;
+		}
 
-        $tld = $this->config->get('tld');
+		$tld = $this->config->get('tld');
 
-        foreach ($secured->pluck('site') as $domain) {
-            $this->cli->run(sprintf('cmd "/C certutil -delstore "Root" "%s""', $domain.'.'.$tld));
-        }
-    }
+		foreach ($secured->pluck('site') as $domain) {
+			$this->cli->run(sprintf('cmd "/C certutil -delstore "Root" "%s""', $domain . '.' . $tld));
+		}
+	}
 
-    /**
-     * Build the Nginx proxy config for the specified domain.
-     *
-     * @param  string  $url  The domain name to serve
-     * @param  string  $host  The URL to proxy to, eg: http://127.0.0.1:8080
-     * @return string
-     */
-    public function proxyCreate($url, $host)
-    {
-        if (! preg_match('~^https?://.*$~', $host)) {
-            throw new \InvalidArgumentException(sprintf('"%s" is not a valid URL', $host));
-        }
+	/**
+	 * Build the Nginx proxy config for the specified domain.
+	 *
+	 * @param  string  $url  The domain name to serve
+	 * @param  string  $host  The URL to proxy to, eg: http://127.0.0.1:8080
+	 * @return string
+	 */
+	public function proxyCreate($url, $host)
+	{
+		if (!preg_match('~^https?://.*$~', $host)) {
+			throw new \InvalidArgumentException(sprintf('"%s" is not a valid URL', $host));
+		}
 
-        $tld = $this->config->read()['tld'];
-        if (! ends_with($url, '.'.$tld)) {
-            $url .= '.'.$tld;
-        }
+		$tld = $this->config->read()['tld'];
+		if (!ends_with($url, '.' . $tld)) {
+			$url .= '.' . $tld;
+		}
 
-        $siteConf = $this->files->get(__DIR__.'/../stubs/proxy.valet.conf');
+		$siteConf = $this->files->get(__DIR__ . '/../stubs/proxy.valet.conf');
 
-        $siteConf = str_replace(
-            ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'VALET_SITE', 'VALET_PROXY_HOST'],
-            [$this->valetHomePath(), VALET_SERVER_PATH, VALET_STATIC_PREFIX, $url, $host],
-            $siteConf
-        );
+		$siteConf = str_replace(
+			['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'VALET_SITE', 'VALET_PROXY_HOST'],
+			[$this->valetHomePath(), VALET_SERVER_PATH, VALET_STATIC_PREFIX, $url, $host],
+			$siteConf
+		);
 
-        $this->secure($url, $siteConf);
+		$this->secure($url, $siteConf);
 
-        info('Valet will now proxy [https://'.$url.'] traffic to ['.$host.'].');
-    }
+		info('Valet will now proxy [https://' . $url . '] traffic to [' . $host . '].');
+	}
 
-    /**
-     * Unsecure the given URL so that it will use HTTP again.
-     *
-     * @param  string  $url
-     * @return void
-     */
-    public function proxyDelete($url)
-    {
-        $tld = $this->config->read()['tld'];
-        if (! ends_with($url, '.'.$tld)) {
-            $url .= '.'.$tld;
-        }
+	/**
+	 * Unsecure the given URL so that it will use HTTP again.
+	 *
+	 * @param  string  $url
+	 * @return void
+	 */
+	public function proxyDelete($url)
+	{
+		$tld = $this->config->read()['tld'];
+		if (!ends_with($url, '.' . $tld)) {
+			$url .= '.' . $tld;
+		}
 
-        $this->unsecure($url);
-        $this->files->unlink($this->nginxPath($url));
+		$this->unsecure($url);
+		$this->files->unlink($this->nginxPath($url));
 
-        info('Valet will no longer proxy [https://'.$url.'].');
-    }
+		info('Valet will no longer proxy [https://' . $url . '].');
+	}
 
-    public function valetHomePath()
-    {
-        return VALET_HOME_PATH;
-    }
+	public function valetHomePath()
+	{
+		return VALET_HOME_PATH;
+	}
 
-    /**
-     * Get the path to Nginx site configuration files.
-     */
-    public function nginxPath($additionalPath = null)
-    {
-        if ($additionalPath && ! ends_with($additionalPath, '.conf')) {
-            $additionalPath = $additionalPath.'.conf';
-        }
+	/**
+	 * Get the path to Nginx site configuration files.
+	 */
+	public function nginxPath($additionalPath = null)
+	{
+		if ($additionalPath && !ends_with($additionalPath, '.conf')) {
+			$additionalPath = $additionalPath . '.conf';
+		}
 
-        return $this->valetHomePath().'/Nginx'.($additionalPath ? '/'.$additionalPath : '');
-    }
+		return $this->valetHomePath() . '/Nginx' . ($additionalPath ? '/' . $additionalPath : '');
+	}
 
-    /**
-     * Get the path to the linked Valet sites.
-     *
-     * @return string
-     */
-    public function sitesPath($link = null)
-    {
-        return $this->valetHomePath().'/Sites'.($link ? '/'.$link : '');
-    }
+	/**
+	 * Get the path to the linked Valet sites.
+	 *
+	 * @return string
+	 */
+	public function sitesPath($link = null)
+	{
+		return $this->valetHomePath() . '/Sites' . ($link ? '/' . $link : '');
+	}
 
-    /**
-     * Get the path to the Valet TLS certificates.
-     *
-     * @return string
-     */
-    public function certificatesPath($url = null, $extension = null)
-    {
-        $url = $url ? '/'.$url : '';
-        $extension = $extension ? '.'.$extension : '';
+	/**
+	 * Get the path to the Valet TLS certificates.
+	 *
+	 * @return string
+	 */
+	public function certificatesPath($url = null, $extension = null)
+	{
+		$url = $url ? '/' . $url : '';
+		$extension = $extension ? '.' . $extension : '';
 
-        return $this->valetHomePath().'/Certificates'.$url.$extension;
-    }
+		return $this->valetHomePath() . '/Certificates' . $url . $extension;
+	}
 }

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -297,11 +297,12 @@ class Site
             $secured = $certs->has($site);
             $url = ($secured ? 'https' : 'http').'://'.$site.'.'.$config['tld'];
             $phpVersion = $this->customPhpVersion($site.'.'.$config['tld']);
+			$defaultVersion = $this->config->get('default_php');
 
             return [
                 'site' => $site,
                 'secured' => $secured ? ' X' : '',
-                'php' => $phpVersion,
+                'php' => $phpVersion ? "$phpVersion <info>(isolated)</info>" : "$defaultVersion (default)",
                 'url' => $url,
                 'path' => $path,
             ];

--- a/cli/Valet/Valet.php
+++ b/cli/Valet/Valet.php
@@ -6,115 +6,115 @@ use Httpful\Request;
 
 class Valet
 {
-    protected $cli;
-    protected $files;
+	protected $cli;
+	protected $files;
 
-    /**
-     * Create a new Valet instance.
-     *
-     * @param  CommandLine  $cli
-     * @param  Filesystem  $files
-     * @return void
-     */
-    public function __construct(CommandLine $cli, Filesystem $files)
-    {
-        $this->cli = $cli;
-        $this->files = $files;
-    }
+	/**
+	 * Create a new Valet instance.
+	 *
+	 * @param  CommandLine  $cli
+	 * @param  Filesystem  $files
+	 * @return void
+	 */
+	public function __construct(CommandLine $cli, Filesystem $files)
+	{
+		$this->cli = $cli;
+		$this->files = $files;
+	}
 
-    /**
-     * Get the paths to all of the Valet extensions.
-     *
-     * @return array
-     */
-    public function extensions(): array
-    {
-        $path = static::homePath('Extensions');
+	/**
+	 * Get the paths to all of the Valet extensions.
+	 *
+	 * @return array
+	 */
+	public function extensions(): array
+	{
+		$path = static::homePath('Extensions');
 
-        if (! $this->files->isDir($path)) {
-            return [];
-        }
+		if (! $this->files->isDir($path)) {
+			return [];
+		}
 
-        return collect($this->files->scandir($path))
-            ->reject(function ($file) {
-                return is_dir($file);
-            })
-            ->map(function ($file) use ($path) {
-                return $path.DIRECTORY_SEPARATOR.$file;
-            })
-            ->values()->all();
-    }
+		return collect($this->files->scandir($path))
+			->reject(function ($file) {
+				return is_dir($file);
+			})
+			->map(function ($file) use ($path) {
+				return $path.DIRECTORY_SEPARATOR.$file;
+			})
+			->values()->all();
+	}
 
-    /**
-     * Get the installed Valet services.
-     *
-     * @return array
-     */
-    public function services(): array
-    {
-        return collect([
-            'acrylic' => 'AcrylicDNSProxySvc',
-            'nginx' => 'valet_nginx',
-            'php' => 'valet_phpcgi',
-            'php-xdebug' => 'valet_phpcgi_xdebug',
-        ])->map(function ($id, $service) {
-            $output = $this->cli->run('powershell -command "Get-Service -Name '.$id.'"');
+	/**
+	 * Get the installed Valet services.
+	 *
+	 * @return array
+	 */
+	public function services(): array
+	{
+		return collect([
+			'acrylic' => 'AcrylicDNSProxySvc',
+			'nginx' => 'valet_nginx',
+			'php' => 'valet_phpcgi',
+			'php-xdebug' => 'valet_phpcgi_xdebug',
+		])->map(function ($id, $service) {
+			$output = $this->cli->run('powershell -command "Get-Service -Name '.$id.'"');
 
-            if (strpos($output, 'Running') > -1) {
-                $status = '<fg=green>running</>';
-            } elseif (strpos($output, 'Stopped') > -1) {
-                $status = '<fg=yellow>stopped</>';
-            } else {
-                $status = '<fg=red>missing</>';
-            }
+			if (strpos($output, 'Running') > -1) {
+				$status = '<fg=green>running</>';
+			} elseif (strpos($output, 'Stopped') > -1) {
+				$status = '<fg=yellow>stopped</>';
+			} else {
+				$status = '<fg=red>missing</>';
+			}
 
-            return [
-                'service' => $service,
-                'winname' => $id,
-                'status' => $status,
-            ];
-        })->values()->all();
-    }
+			return [
+				'service' => $service,
+				'winname' => $id,
+				'status' => $status,
+			];
+		})->values()->all();
+	}
 
-    /**
-     * Determine if this is the latest version of Valet.
-     *
-     * @param  string  $currentVersion
-     * @return bool
-     *
-     * @throws \Httpful\Exception\ConnectionErrorException
-     */
-    public function onLatestVersion($currentVersion): bool
-    {
-        $response = Request::get('https://api.github.com/repos/cretueusebiu/valet-windows/releases/latest')->send();
+	/**
+	 * Determine if this is the latest version of Valet.
+	 *
+	 * @param  string  $currentVersion
+	 * @return bool
+	 *
+	 * @throws \Httpful\Exception\ConnectionErrorException
+	 */
+	public function onLatestVersion($currentVersion): bool
+	{
+		$response = Request::get('https://api.github.com/repos/cretueusebiu/valet-windows/releases/latest')->send();
 
-        return version_compare($currentVersion, trim($response->body->tag_name, 'v'), '>=');
-    }
+		return version_compare($currentVersion, trim($response->body->tag_name, 'v'), '>=');
+	}
 
-    /**
-     * Run composer global diagnose.
-     */
-    public function composerGlobalDiagnose()
-    {
-        $this->cli->runAsUser('composer global diagnose');
-    }
+	/**
+	 * Run composer global diagnose.
+	 */
+	public function composerGlobalDiagnose()
+	{
+		$this->cli->runAsUser('composer global diagnose');
+	}
 
-    /**
-     * Run composer global update.
-     */
-    public function composerGlobalUpdate()
-    {
-        $this->cli->runAsUser('composer global update');
-    }
+	/**
+	 * Run composer global update.
+	 */
+	public function composerGlobalUpdate()
+	{
+		$this->cli->runAsUser('composer global update');
+	}
 
-    /**
-     * Get the Valet home path (VALET_HOME_PATH = ~/.config/valet).
-     *
-     * @param  string  $path
-     * @return string
-     */
-    public static function homePath(string $path = ''): string
-    {
-        return VALET_HOME_PATH.($path ? DIRECTORY_SEPARATOR.$path : $path);
-    }
+	/**
+	 * Get the Valet home path (VALET_HOME_PATH = ~/.config/valet).
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	public static function homePath(string $path = ''): string
+	{
+		return VALET_HOME_PATH.($path ? DIRECTORY_SEPARATOR.$path : $path);
+	}
 }

--- a/cli/Valet/WinSW.php
+++ b/cli/Valet/WinSW.php
@@ -4,168 +4,168 @@ namespace Valet;
 
 class WinSW
 {
-    /**
-     * @var string
-     */
-    protected $service;
+	/**
+	 * @var string
+	 */
+	protected $service;
 
-    /**
-     * @var CommandLine
-     */
-    protected $cli;
+	/**
+	 * @var CommandLine
+	 */
+	protected $cli;
 
-    /**
-     * @var Filesystem
-     */
-    protected $files;
+	/**
+	 * @var Filesystem
+	 */
+	protected $files;
 
-    /**
-     * Create a new WinSW instance.
-     *
-     * @param  CommandLine  $cli
-     * @param  Filesystem  $files
-     * @return void
-     */
-    public function __construct(string $service, CommandLine $cli, Filesystem $files)
-    {
-        $this->cli = $cli;
-        $this->files = $files;
-        $this->service = $service;
-    }
+	/**
+	 * Create a new WinSW instance.
+	 *
+	 * @param  CommandLine  $cli
+	 * @param  Filesystem  $files
+	 * @return void
+	 */
+	public function __construct(string $service, CommandLine $cli, Filesystem $files)
+	{
+		$this->cli = $cli;
+		$this->files = $files;
+		$this->service = $service;
+	}
 
-    /**
-     * Install the service.
-     *
-     * @param  array  $args
-     * @return void
-     */
-    public function install(array $args = [])
-    {
-        $this->createConfiguration($args);
+	/**
+	 * Install the service.
+	 *
+	 * @param  array  $args
+	 * @return void
+	 */
+	public function install(array $args = [])
+	{
+		$this->createConfiguration($args);
 
-        $command = 'cmd "/C cd '.$this->servicesPath().' && "'.$this->servicesPath($this->service).'" install"';
+		$command = 'cmd "/C cd '.$this->servicesPath().' && "'.$this->servicesPath($this->service).'" install"';
 
-        $this->cli->runOrExit($command, function ($code, $output) {
-            error("Failed to install service [$this->service]. Check ~/.config/valet/Log for errors.\n$output");
-        });
-    }
+		$this->cli->runOrExit($command, function ($code, $output) {
+			error("Failed to install service [$this->service]. Check ~/.config/valet/Log for errors.\n$output");
+		});
+	}
 
-    /**
-     * Create the .exe and .xml files.
-     *
-     * @param  array  $args
-     * @return void
-     */
-    protected function createConfiguration(array $args = [])
-    {
-        $args['VALET_HOME_PATH'] = Valet::homePath();
+	/**
+	 * Create the .exe and .xml files.
+	 *
+	 * @param  array  $args
+	 * @return void
+	 */
+	protected function createConfiguration(array $args = [])
+	{
+		$args['VALET_HOME_PATH'] = Valet::homePath();
 
-        $this->files->copy(
-            realpath(__DIR__.'/../../bin/winsw/WinSW.NET4.exe'),
-            $this->binaryPath()
-        );
+		$this->files->copy(
+			realpath(__DIR__.'/../../bin/winsw/WinSW.NET4.exe'),
+			$this->binaryPath()
+		);
 
-        $config = $this->files->get(__DIR__."/../stubs/$this->service.xml");
+		$config = $this->files->get(__DIR__."/../stubs/$this->service.xml");
 
-        $this->files->put(
-            $this->configPath(),
-            str_replace(array_keys($args), array_values($args), $config ?: '')
-        );
-    }
+		$this->files->put(
+			$this->configPath(),
+			str_replace(array_keys($args), array_values($args), $config ?: '')
+		);
+	}
 
-    /**
-     * Uninstall the service.
-     *
-     * @return void
-     */
-    public function uninstall()
-    {
-        $this->stop($this->service);
+	/**
+	 * Uninstall the service.
+	 *
+	 * @return void
+	 */
+	public function uninstall()
+	{
+		$this->stop($this->service);
 
-        $this->cli->run('cmd "/C cd '.$this->servicesPath().' && "'.$this->servicesPath($this->service).'" uninstall"');
+		$this->cli->run('cmd "/C cd '.$this->servicesPath().' && "'.$this->servicesPath($this->service).'" uninstall"');
 
-        sleep(1);
+		sleep(1);
 
-        $this->files->unlink($this->binaryPath());
-        $this->files->unlink($this->configPath());
-    }
+		$this->files->unlink($this->binaryPath());
+		$this->files->unlink($this->configPath());
+	}
 
-    /**
-     * Determine if the service is installed.
-     *
-     * @return bool
-     */
-    public function installed(): bool
-    {
-        $name = 'valet_'.str_replace('service', '', $this->service);
+	/**
+	 * Determine if the service is installed.
+	 *
+	 * @return bool
+	 */
+	public function installed(): bool
+	{
+		$name = 'valet_'.str_replace('service', '', $this->service);
 
-        if ($name === 'valet_phpcgixdebug') {
-            $name = 'valet_phpcgi_xdebug';
-        }
+		if ($name === 'valet_phpcgixdebug') {
+			$name = 'valet_phpcgi_xdebug';
+		}
 
-        return $this->cli->powershell("Get-Service -Name \"$name\"")->isSuccessful();
-    }
+		return $this->cli->powershell("Get-Service -Name \"$name\"")->isSuccessful();
+	}
 
-    /**
-     * Restart the service.
-     *
-     * @return void
-     */
-    public function restart()
-    {
-        $command = 'cmd "/C cd '.$this->servicesPath().' && "'.$this->servicesPath($this->service).'" restart"';
+	/**
+	 * Restart the service.
+	 *
+	 * @return void
+	 */
+	public function restart()
+	{
+		$command = 'cmd "/C cd '.$this->servicesPath().' && "'.$this->servicesPath($this->service).'" restart"';
 
-        $this->cli->run($command, function () use ($command) {
-            sleep(2);
+		$this->cli->run($command, function () use ($command) {
+			sleep(2);
 
-            $this->cli->runOrExit($command, function ($code, $output) {
-                error("Failed to restart service [$this->service]. Check ~/.config/valet/Log for errors.\n$output");
-            });
-        });
-    }
+			$this->cli->runOrExit($command, function ($code, $output) {
+				error("Failed to restart service [$this->service]. Check ~/.config/valet/Log for errors.\n$output");
+			});
+		});
+	}
 
-    /**
-     * Stop the service.
-     *
-     * @return void
-     */
-    public function stop()
-    {
-        $command = 'cmd "/C cd '.$this->servicesPath().' && "'.$this->servicesPath($this->service).'" stop"';
+	/**
+	 * Stop the service.
+	 *
+	 * @return void
+	 */
+	public function stop()
+	{
+		$command = 'cmd "/C cd '.$this->servicesPath().' && "'.$this->servicesPath($this->service).'" stop"';
 
-        $this->cli->run($command, function ($code, $output) {
-            warning("Failed to stop service [$this->service].\n$output");
-        });
-    }
+		$this->cli->run($command, function ($code, $output) {
+			warning("Failed to stop service [$this->service].\n$output");
+		});
+	}
 
-    /**
-     * Get the config path.
-     *
-     * @return string
-     */
-    protected function configPath(): string
-    {
-        return $this->servicesPath("$this->service.xml");
-    }
+	/**
+	 * Get the config path.
+	 *
+	 * @return string
+	 */
+	protected function configPath(): string
+	{
+		return $this->servicesPath("$this->service.xml");
+	}
 
-    /**
-     * Get the binary path.
-     *
-     * @return string
-     */
-    protected function binaryPath(): string
-    {
-        return $this->servicesPath("$this->service.exe");
-    }
+	/**
+	 * Get the binary path.
+	 *
+	 * @return string
+	 */
+	protected function binaryPath(): string
+	{
+		return $this->servicesPath("$this->service.exe");
+	}
 
-    /**
-     * Get the services path.
-     *
-     * @param  string  $path
-     * @return string
-     */
-    protected function servicesPath(string $path = ''): string
-    {
-        return Valet::homePath('Services'.($path ? DIRECTORY_SEPARATOR.$path : $path));
-    }
+	/**
+	 * Get the services path.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	protected function servicesPath(string $path = ''): string
+	{
+		return Valet::homePath('Services'.($path ? DIRECTORY_SEPARATOR.$path : $path));
+	}
 }

--- a/cli/Valet/WinSwFactory.php
+++ b/cli/Valet/WinSwFactory.php
@@ -4,41 +4,41 @@ namespace Valet;
 
 class WinSwFactory
 {
-    /**
-     * @var CommandLine
-     */
-    protected $cli;
+	/**
+	 * @var CommandLine
+	 */
+	protected $cli;
 
-    /**
-     * @var Filesystem
-     */
-    protected $files;
+	/**
+	 * @var Filesystem
+	 */
+	protected $files;
 
-    /**
-     * Create a new factory instance.
-     *
-     * @param  CommandLine  $cli
-     * @param  Filesystem  $files
-     * @return void
-     */
-    public function __construct(CommandLine $cli, Filesystem $files)
-    {
-        $this->cli = $cli;
-        $this->files = $files;
-    }
+	/**
+	 * Create a new factory instance.
+	 *
+	 * @param  CommandLine  $cli
+	 * @param  Filesystem  $files
+	 * @return void
+	 */
+	public function __construct(CommandLine $cli, Filesystem $files)
+	{
+		$this->cli = $cli;
+		$this->files = $files;
+	}
 
-    /**
-     * Make a new WinSW instance.
-     *
-     * @param  string  $service
-     * @return WinSW
-     */
-    public function make(string $service)
-    {
-        return new WinSW(
-            $service,
-            $this->cli,
-            $this->files
-        );
-    }
+	/**
+	 * Make a new WinSW instance.
+	 *
+	 * @param  string  $service
+	 * @return WinSW
+	 */
+	public function make(string $service)
+	{
+		return new WinSW(
+			$service,
+			$this->cli,
+			$this->files
+		);
+	}
 }

--- a/cli/drivers/BasicValetDriver.php
+++ b/cli/drivers/BasicValetDriver.php
@@ -2,155 +2,155 @@
 
 class BasicValetDriver extends ValetDriver
 {
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return true;
-    }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return true;
+	}
 
-    /**
-     * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
-     */
-    public function isStaticFile($sitePath, $siteName, $uri)
-    {
-        if (file_exists($staticFilePath = $sitePath.'/public'.rtrim($uri, '/').'/index.html')) {
-            return $staticFilePath;
-        } elseif (file_exists($staticFilePath = $sitePath.'/public'.rtrim($uri, '/').'/index.php')) {
-            return $staticFilePath;
-        } elseif (file_exists($staticFilePath = $sitePath.'/public'.$uri)) {
-            return $staticFilePath;
-        } elseif ($this->isActualFile($staticFilePath = $sitePath.$uri)) {
-            return $staticFilePath;
-        }
+	/**
+	 * Determine if the incoming request is for a static file.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string|false
+	 */
+	public function isStaticFile($sitePath, $siteName, $uri)
+	{
+		if (file_exists($staticFilePath = $sitePath.'/public'.rtrim($uri, '/').'/index.html')) {
+			return $staticFilePath;
+		} elseif (file_exists($staticFilePath = $sitePath.'/public'.rtrim($uri, '/').'/index.php')) {
+			return $staticFilePath;
+		} elseif (file_exists($staticFilePath = $sitePath.'/public'.$uri)) {
+			return $staticFilePath;
+		} elseif ($this->isActualFile($staticFilePath = $sitePath.$uri)) {
+			return $staticFilePath;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        $_SERVER['PHP_SELF'] = $uri;
-        $_SERVER['SERVER_ADDR'] = '127.0.0.1';
-        $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		$_SERVER['PHP_SELF'] = $uri;
+		$_SERVER['SERVER_ADDR'] = '127.0.0.1';
+		$_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
 
-        $dynamicCandidates = [
-            $this->asActualFile($sitePath, $uri),
-            $this->asPhpIndexFileInDirectory($sitePath, $uri),
-            $this->asHtmlIndexFileInDirectory($sitePath, $uri),
-        ];
+		$dynamicCandidates = [
+			$this->asActualFile($sitePath, $uri),
+			$this->asPhpIndexFileInDirectory($sitePath, $uri),
+			$this->asHtmlIndexFileInDirectory($sitePath, $uri),
+		];
 
-        foreach ($dynamicCandidates as $candidate) {
-            if ($this->isActualFile($candidate)) {
-                $_SERVER['SCRIPT_FILENAME'] = $candidate;
-                $_SERVER['SCRIPT_NAME'] = str_replace($sitePath, '', $candidate);
-                $_SERVER['DOCUMENT_ROOT'] = $sitePath;
+		foreach ($dynamicCandidates as $candidate) {
+			if ($this->isActualFile($candidate)) {
+				$_SERVER['SCRIPT_FILENAME'] = $candidate;
+				$_SERVER['SCRIPT_NAME'] = str_replace($sitePath, '', $candidate);
+				$_SERVER['DOCUMENT_ROOT'] = $sitePath;
 
-                return $candidate;
-            }
-        }
+				return $candidate;
+			}
+		}
 
-        $fixedCandidatesAndDocroots = [
-            $this->asRootPhpIndexFile($sitePath) => $sitePath,
-            $this->asPublicPhpIndexFile($sitePath) => $sitePath.'/public',
-            $this->asPublicHtmlIndexFile($sitePath) => $sitePath.'/public',
-        ];
+		$fixedCandidatesAndDocroots = [
+			$this->asRootPhpIndexFile($sitePath) => $sitePath,
+			$this->asPublicPhpIndexFile($sitePath) => $sitePath.'/public',
+			$this->asPublicHtmlIndexFile($sitePath) => $sitePath.'/public',
+		];
 
-        foreach ($fixedCandidatesAndDocroots as $candidate => $docroot) {
-            if ($this->isActualFile($candidate)) {
-                $_SERVER['SCRIPT_FILENAME'] = $candidate;
-                $_SERVER['SCRIPT_NAME'] = '/index.php';
-                $_SERVER['DOCUMENT_ROOT'] = $docroot;
+		foreach ($fixedCandidatesAndDocroots as $candidate => $docroot) {
+			if ($this->isActualFile($candidate)) {
+				$_SERVER['SCRIPT_FILENAME'] = $candidate;
+				$_SERVER['SCRIPT_NAME'] = '/index.php';
+				$_SERVER['DOCUMENT_ROOT'] = $docroot;
 
-                return $candidate;
-            }
-        }
-    }
+				return $candidate;
+			}
+		}
+	}
 
-    /**
-     * Concatenate the site path and URI as a single file name.
-     *
-     * @param  string  $sitePath
-     * @param  string  $uri
-     * @return string
-     */
-    protected function asActualFile($sitePath, $uri)
-    {
-        return $sitePath.$uri;
-    }
+	/**
+	 * Concatenate the site path and URI as a single file name.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $uri
+	 * @return string
+	 */
+	protected function asActualFile($sitePath, $uri)
+	{
+		return $sitePath.$uri;
+	}
 
-    /**
-     * Format the site path and URI with a trailing "index.php".
-     *
-     * @param  string  $sitePath
-     * @param  string  $uri
-     * @return string
-     */
-    protected function asPhpIndexFileInDirectory($sitePath, $uri)
-    {
-        return $sitePath.rtrim($uri, '/').'/index.php';
-    }
+	/**
+	 * Format the site path and URI with a trailing "index.php".
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $uri
+	 * @return string
+	 */
+	protected function asPhpIndexFileInDirectory($sitePath, $uri)
+	{
+		return $sitePath.rtrim($uri, '/').'/index.php';
+	}
 
-    /**
-     * Format the site path and URI with a trailing "index.html".
-     *
-     * @param  string  $sitePath
-     * @param  string  $uri
-     * @return string
-     */
-    protected function asHtmlIndexFileInDirectory($sitePath, $uri)
-    {
-        return $sitePath.rtrim($uri, '/').'/index.html';
-    }
+	/**
+	 * Format the site path and URI with a trailing "index.html".
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $uri
+	 * @return string
+	 */
+	protected function asHtmlIndexFileInDirectory($sitePath, $uri)
+	{
+		return $sitePath.rtrim($uri, '/').'/index.html';
+	}
 
-    /**
-     * Format the incoming site path as root "index.php" file path.
-     *
-     * @param  string  $sitePath
-     * @return string
-     */
-    protected function asRootPhpIndexFile($sitePath)
-    {
-        return $sitePath.'/index.php';
-    }
+	/**
+	 * Format the incoming site path as root "index.php" file path.
+	 *
+	 * @param  string  $sitePath
+	 * @return string
+	 */
+	protected function asRootPhpIndexFile($sitePath)
+	{
+		return $sitePath.'/index.php';
+	}
 
-    /**
-     * Format the incoming site path as a "public/index.php" file path.
-     *
-     * @param  string  $sitePath
-     * @return string
-     */
-    protected function asPublicPhpIndexFile($sitePath)
-    {
-        return $sitePath.'/public/index.php';
-    }
+	/**
+	 * Format the incoming site path as a "public/index.php" file path.
+	 *
+	 * @param  string  $sitePath
+	 * @return string
+	 */
+	protected function asPublicPhpIndexFile($sitePath)
+	{
+		return $sitePath.'/public/index.php';
+	}
 
-    /**
-     * Format the incoming site path as a "public/index.php" file path.
-     *
-     * @param  string  $sitePath
-     * @return string
-     */
-    protected function asPublicHtmlIndexFile($sitePath)
-    {
-        return $sitePath.'/public/index.html';
-    }
+	/**
+	 * Format the incoming site path as a "public/index.php" file path.
+	 *
+	 * @param  string  $sitePath
+	 * @return string
+	 */
+	protected function asPublicHtmlIndexFile($sitePath)
+	{
+		return $sitePath.'/public/index.html';
+	}
 }

--- a/cli/drivers/BedrockValetDriver.php
+++ b/cli/drivers/BedrockValetDriver.php
@@ -2,76 +2,76 @@
 
 class BedrockValetDriver extends BasicValetDriver
 {
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return file_exists($sitePath.'/web/app/mu-plugins/bedrock-autoloader.php') ||
-              (is_dir($sitePath.'/web/app/') &&
-               file_exists($sitePath.'/web/wp-config.php') &&
-               file_exists($sitePath.'/config/application.php'));
-    }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return file_exists($sitePath.'/web/app/mu-plugins/bedrock-autoloader.php') ||
+			  (is_dir($sitePath.'/web/app/') &&
+			   file_exists($sitePath.'/web/wp-config.php') &&
+			   file_exists($sitePath.'/config/application.php'));
+	}
 
-    /**
-     * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
-     */
-    public function isStaticFile($sitePath, $siteName, $uri)
-    {
-        $staticFilePath = $sitePath.'/web'.$uri;
+	/**
+	 * Determine if the incoming request is for a static file.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string|false
+	 */
+	public function isStaticFile($sitePath, $siteName, $uri)
+	{
+		$staticFilePath = $sitePath.'/web'.$uri;
 
-        if ($this->isActualFile($staticFilePath)) {
-            return $staticFilePath;
-        }
+		if ($this->isActualFile($staticFilePath)) {
+			return $staticFilePath;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        $_SERVER['PHP_SELF'] = $uri;
-        $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		$_SERVER['PHP_SELF'] = $uri;
+		$_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
 
-        if (strpos($uri, '/wp/') === 0) {
-            return is_dir($sitePath.'/web'.$uri)
-                            ? $sitePath.'/web'.$this->forceTrailingSlash($uri).'/index.php'
-                            : $sitePath.'/web'.$uri;
-        }
+		if (strpos($uri, '/wp/') === 0) {
+			return is_dir($sitePath.'/web'.$uri)
+							? $sitePath.'/web'.$this->forceTrailingSlash($uri).'/index.php'
+							: $sitePath.'/web'.$uri;
+		}
 
-        return $sitePath.'/web/index.php';
-    }
+		return $sitePath.'/web/index.php';
+	}
 
-    /**
-     * Redirect to uri with trailing slash.
-     *
-     * @param  string  $uri
-     * @return string
-     */
-    private function forceTrailingSlash($uri)
-    {
-        if (substr($uri, -1 * strlen('/wp/wp-admin')) == '/wp/wp-admin') {
-            header('Location: '.$uri.'/');
-            exit;
-        }
+	/**
+	 * Redirect to uri with trailing slash.
+	 *
+	 * @param  string  $uri
+	 * @return string
+	 */
+	private function forceTrailingSlash($uri)
+	{
+		if (substr($uri, -1 * strlen('/wp/wp-admin')) == '/wp/wp-admin') {
+			header('Location: '.$uri.'/');
+			exit;
+		}
 
-        return $uri;
-    }
+		return $uri;
+	}
 }

--- a/cli/drivers/CakeValetDriver.php
+++ b/cli/drivers/CakeValetDriver.php
@@ -2,51 +2,51 @@
 
 class CakeValetDriver extends ValetDriver
 {
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return file_exists($sitePath.'/bin/cake');
-    }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return file_exists($sitePath.'/bin/cake');
+	}
 
-    /**
-     * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
-     */
-    public function isStaticFile($sitePath, $siteName, $uri)
-    {
-        if ($this->isActualFile($staticFilePath = $sitePath.'/webroot/'.$uri)) {
-            return $staticFilePath;
-        }
+	/**
+	 * Determine if the incoming request is for a static file.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string|false
+	 */
+	public function isStaticFile($sitePath, $siteName, $uri)
+	{
+		if ($this->isActualFile($staticFilePath = $sitePath.'/webroot/'.$uri)) {
+			return $staticFilePath;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        $_SERVER['DOCUMENT_ROOT'] = $sitePath.'/webroot';
-        $_SERVER['SCRIPT_FILENAME'] = $sitePath.'/webroot/index.php';
-        $_SERVER['SCRIPT_NAME'] = '/index.php';
-        $_SERVER['PHP_SELF'] = '/index.php';
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		$_SERVER['DOCUMENT_ROOT'] = $sitePath.'/webroot';
+		$_SERVER['SCRIPT_FILENAME'] = $sitePath.'/webroot/index.php';
+		$_SERVER['SCRIPT_NAME'] = '/index.php';
+		$_SERVER['PHP_SELF'] = '/index.php';
 
-        return $sitePath.'/webroot/index.php';
-    }
+		return $sitePath.'/webroot/index.php';
+	}
 }

--- a/cli/drivers/Concrete5ValetDriver.php
+++ b/cli/drivers/Concrete5ValetDriver.php
@@ -2,46 +2,46 @@
 
 class Concrete5ValetDriver extends BasicValetDriver
 {
-    /**
-     * If a concrete directory exists, it's probably c5.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return file_exists($sitePath.'/concrete/config/install/base');
-    }
+	/**
+	 * If a concrete directory exists, it's probably c5.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return file_exists($sitePath.'/concrete/config/install/base');
+	}
 
-    /**
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        if (! getenv('CONCRETE5_ENV')) {
-            putenv('CONCRETE5_ENV=valet');
-        }
+	/**
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		if (! getenv('CONCRETE5_ENV')) {
+			putenv('CONCRETE5_ENV=valet');
+		}
 
-        $matches = [];
-        if (preg_match('/^\/(.*?)\.php/', $uri, $matches)) {
-            $filename = $matches[0];
+		$matches = [];
+		if (preg_match('/^\/(.*?)\.php/', $uri, $matches)) {
+			$filename = $matches[0];
 
-            if (file_exists($sitePath.$filename) && ! is_dir($sitePath.$filename)) {
-                $_SERVER['SCRIPT_FILENAME'] = $sitePath.$filename;
-                $_SERVER['SCRIPT_NAME'] = $filename;
+			if (file_exists($sitePath.$filename) && ! is_dir($sitePath.$filename)) {
+				$_SERVER['SCRIPT_FILENAME'] = $sitePath.$filename;
+				$_SERVER['SCRIPT_NAME'] = $filename;
 
-                return $sitePath.$filename;
-            }
-        }
+				return $sitePath.$filename;
+			}
+		}
 
-        $_SERVER['SCRIPT_FILENAME'] = $sitePath.'/index.php';
-        $_SERVER['SCRIPT_NAME'] = '/index.php';
+		$_SERVER['SCRIPT_FILENAME'] = $sitePath.'/index.php';
+		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
-        return $sitePath.'/index.php';
-    }
+		return $sitePath.'/index.php';
+	}
 }

--- a/cli/drivers/ContaoValetDriver.php
+++ b/cli/drivers/ContaoValetDriver.php
@@ -2,57 +2,57 @@
 
 class ContaoValetDriver extends ValetDriver
 {
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return is_dir($sitePath.'/vendor/contao') && file_exists($sitePath.'/web/app.php');
-    }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return is_dir($sitePath.'/vendor/contao') && file_exists($sitePath.'/web/app.php');
+	}
 
-    /**
-     * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
-     */
-    public function isStaticFile($sitePath, $siteName, $uri)
-    {
-        if ($this->isActualFile($staticFilePath = $sitePath.'/web'.$uri)) {
-            return $staticFilePath;
-        }
+	/**
+	 * Determine if the incoming request is for a static file.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string|false
+	 */
+	public function isStaticFile($sitePath, $siteName, $uri)
+	{
+		if ($this->isActualFile($staticFilePath = $sitePath.'/web'.$uri)) {
+			return $staticFilePath;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        if ($uri === '/install.php') {
-            return $sitePath.'/web/install.php';
-        }
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		if ($uri === '/install.php') {
+			return $sitePath.'/web/install.php';
+		}
 
-        if (0 === strncmp($uri, '/app_dev.php', 12)) {
-            $_SERVER['SCRIPT_NAME'] = '/app_dev.php';
-            $_SERVER['SCRIPT_FILENAME'] = $sitePath.'/app_dev.php';
+		if (0 === strncmp($uri, '/app_dev.php', 12)) {
+			$_SERVER['SCRIPT_NAME'] = '/app_dev.php';
+			$_SERVER['SCRIPT_FILENAME'] = $sitePath.'/app_dev.php';
 
-            return $sitePath.'/web/app_dev.php';
-        }
+			return $sitePath.'/web/app_dev.php';
+		}
 
-        return $sitePath.'/web/app.php';
-    }
+		return $sitePath.'/web/app.php';
+	}
 }

--- a/cli/drivers/CraftValetDriver.php
+++ b/cli/drivers/CraftValetDriver.php
@@ -2,210 +2,210 @@
 
 class CraftValetDriver extends ValetDriver
 {
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return file_exists($sitePath.'/craft');
-    }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return file_exists($sitePath.'/craft');
+	}
 
-    /**
-     * Determine the name of the directory where the front controller lives.
-     *
-     * @param  string  $sitePath
-     * @return string
-     */
-    public function frontControllerDirectory($sitePath)
-    {
-        $dirs = ['web', 'public'];
+	/**
+	 * Determine the name of the directory where the front controller lives.
+	 *
+	 * @param  string  $sitePath
+	 * @return string
+	 */
+	public function frontControllerDirectory($sitePath)
+	{
+		$dirs = ['web', 'public'];
 
-        foreach ($dirs as $dir) {
-            if (is_dir($sitePath.'/'.$dir)) {
-                return $dir;
-            }
-        }
-        // Give up, and just return the default
-        return is_file($sitePath.'/craft') ? 'web' : 'public';
-    }
+		foreach ($dirs as $dir) {
+			if (is_dir($sitePath.'/'.$dir)) {
+				return $dir;
+			}
+		}
+		// Give up, and just return the default
+		return is_file($sitePath.'/craft') ? 'web' : 'public';
+	}
 
-    /**
-     * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
-     */
-    public function isStaticFile($sitePath, $siteName, $uri)
-    {
-        $frontControllerDirectory = $this->frontControllerDirectory($sitePath);
+	/**
+	 * Determine if the incoming request is for a static file.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string|false
+	 */
+	public function isStaticFile($sitePath, $siteName, $uri)
+	{
+		$frontControllerDirectory = $this->frontControllerDirectory($sitePath);
 
-        if ($this->isActualFile($staticFilePath = $sitePath.'/'.$frontControllerDirectory.$uri)) {
-            return $staticFilePath;
-        }
+		if ($this->isActualFile($staticFilePath = $sitePath.'/'.$frontControllerDirectory.$uri)) {
+			return $staticFilePath;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        $frontControllerDirectory = $this->frontControllerDirectory($sitePath);
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		$frontControllerDirectory = $this->frontControllerDirectory($sitePath);
 
-        // Default index path
-        $indexPath = $sitePath.'/'.$frontControllerDirectory.'/index.php';
-        $scriptName = '/index.php';
+		// Default index path
+		$indexPath = $sitePath.'/'.$frontControllerDirectory.'/index.php';
+		$scriptName = '/index.php';
 
-        // Check if the first URL segment matches any of the defined locales
-        $locales = [
-            'ar',
-            'ar_sa',
-            'bg',
-            'bg_bg',
-            'ca_es',
-            'cs',
-            'cy_gb',
-            'da',
-            'da_dk',
-            'de',
-            'de_at',
-            'de_ch',
-            'de_de',
-            'el',
-            'el_gr',
-            'en',
-            'en_as',
-            'en_au',
-            'en_bb',
-            'en_be',
-            'en_bm',
-            'en_bw',
-            'en_bz',
-            'en_ca',
-            'en_dsrt',
-            'en_dsrt_us',
-            'en_gb',
-            'en_gu',
-            'en_gy',
-            'en_hk',
-            'en_ie',
-            'en_in',
-            'en_jm',
-            'en_mh',
-            'en_mp',
-            'en_mt',
-            'en_mu',
-            'en_na',
-            'en_nz',
-            'en_ph',
-            'en_pk',
-            'en_sg',
-            'en_shaw',
-            'en_tt',
-            'en_um',
-            'en_us',
-            'en_us_posix',
-            'en_vi',
-            'en_za',
-            'en_zw',
-            'en_zz',
-            'es',
-            'es_cl',
-            'es_es',
-            'es_mx',
-            'es_us',
-            'es_ve',
-            'et',
-            'fi',
-            'fi_fi',
-            'fil',
-            'fr',
-            'fr_be',
-            'fr_ca',
-            'fr_ch',
-            'fr_fr',
-            'fr_ma',
-            'he',
-            'hr',
-            'hr_hr',
-            'hu',
-            'hu_hu',
-            'id',
-            'id_id',
-            'it',
-            'it_ch',
-            'it_it',
-            'ja',
-            'ja_jp',
-            'ko',
-            'ko_kr',
-            'lt',
-            'lv',
-            'ms',
-            'ms_my',
-            'nb',
-            'nb_no',
-            'nl',
-            'nl_be',
-            'nl_nl',
-            'nn',
-            'nn_no',
-            'no',
-            'pl',
-            'pl_pl',
-            'pt',
-            'pt_br',
-            'pt_pt',
-            'ro',
-            'ro_ro',
-            'ru',
-            'ru_ru',
-            'sk',
-            'sl',
-            'sr',
-            'sv',
-            'sv_se',
-            'th',
-            'th_th',
-            'tr',
-            'tr_tr',
-            'uk',
-            'vi',
-            'zh',
-            'zh_cn',
-            'zh_tw',
-        ];
-        $parts = explode('/', $uri);
+		// Check if the first URL segment matches any of the defined locales
+		$locales = [
+			'ar',
+			'ar_sa',
+			'bg',
+			'bg_bg',
+			'ca_es',
+			'cs',
+			'cy_gb',
+			'da',
+			'da_dk',
+			'de',
+			'de_at',
+			'de_ch',
+			'de_de',
+			'el',
+			'el_gr',
+			'en',
+			'en_as',
+			'en_au',
+			'en_bb',
+			'en_be',
+			'en_bm',
+			'en_bw',
+			'en_bz',
+			'en_ca',
+			'en_dsrt',
+			'en_dsrt_us',
+			'en_gb',
+			'en_gu',
+			'en_gy',
+			'en_hk',
+			'en_ie',
+			'en_in',
+			'en_jm',
+			'en_mh',
+			'en_mp',
+			'en_mt',
+			'en_mu',
+			'en_na',
+			'en_nz',
+			'en_ph',
+			'en_pk',
+			'en_sg',
+			'en_shaw',
+			'en_tt',
+			'en_um',
+			'en_us',
+			'en_us_posix',
+			'en_vi',
+			'en_za',
+			'en_zw',
+			'en_zz',
+			'es',
+			'es_cl',
+			'es_es',
+			'es_mx',
+			'es_us',
+			'es_ve',
+			'et',
+			'fi',
+			'fi_fi',
+			'fil',
+			'fr',
+			'fr_be',
+			'fr_ca',
+			'fr_ch',
+			'fr_fr',
+			'fr_ma',
+			'he',
+			'hr',
+			'hr_hr',
+			'hu',
+			'hu_hu',
+			'id',
+			'id_id',
+			'it',
+			'it_ch',
+			'it_it',
+			'ja',
+			'ja_jp',
+			'ko',
+			'ko_kr',
+			'lt',
+			'lv',
+			'ms',
+			'ms_my',
+			'nb',
+			'nb_no',
+			'nl',
+			'nl_be',
+			'nl_nl',
+			'nn',
+			'nn_no',
+			'no',
+			'pl',
+			'pl_pl',
+			'pt',
+			'pt_br',
+			'pt_pt',
+			'ro',
+			'ro_ro',
+			'ru',
+			'ru_ru',
+			'sk',
+			'sl',
+			'sr',
+			'sv',
+			'sv_se',
+			'th',
+			'th_th',
+			'tr',
+			'tr_tr',
+			'uk',
+			'vi',
+			'zh',
+			'zh_cn',
+			'zh_tw',
+		];
+		$parts = explode('/', $uri);
 
-        if (count($parts) > 1 && in_array($parts[1], $locales)) {
-            $indexLocalizedPath = $sitePath.'/'.$frontControllerDirectory.'/'.$parts[1].'/index.php';
+		if (count($parts) > 1 && in_array($parts[1], $locales)) {
+			$indexLocalizedPath = $sitePath.'/'.$frontControllerDirectory.'/'.$parts[1].'/index.php';
 
-            // Check if index.php exists in the localized folder, this is optional in Craft 3
-            if (file_exists($indexLocalizedPath)) {
-                $indexPath = $indexLocalizedPath;
-                $scriptName = '/'.$parts[1].'/index.php';
-            }
-        }
+			// Check if index.php exists in the localized folder, this is optional in Craft 3
+			if (file_exists($indexLocalizedPath)) {
+				$indexPath = $indexLocalizedPath;
+				$scriptName = '/'.$parts[1].'/index.php';
+			}
+		}
 
-        $_SERVER['SCRIPT_FILENAME'] = $indexPath;
-        $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
-        $_SERVER['SCRIPT_NAME'] = $scriptName;
-        $_SERVER['PHP_SELF'] = $scriptName;
-        $_SERVER['DOCUMENT_ROOT'] = $sitePath.'/'.$frontControllerDirectory;
+		$_SERVER['SCRIPT_FILENAME'] = $indexPath;
+		$_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+		$_SERVER['SCRIPT_NAME'] = $scriptName;
+		$_SERVER['PHP_SELF'] = $scriptName;
+		$_SERVER['DOCUMENT_ROOT'] = $sitePath.'/'.$frontControllerDirectory;
 
-        return $indexPath;
-    }
+		return $indexPath;
+	}
 }

--- a/cli/drivers/DrupalValetDriver.php
+++ b/cli/drivers/DrupalValetDriver.php
@@ -2,112 +2,112 @@
 
 class DrupalValetDriver extends ValetDriver
 {
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return void
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        $sitePath = $this->addSubdirectory($sitePath);
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return void
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		$sitePath = $this->addSubdirectory($sitePath);
 
-        /**
-         * /misc/drupal.js = Drupal 7
-         * /core/lib/Drupal.php = Drupal 8.
-         */
-        if (file_exists($sitePath.'/misc/drupal.js') ||
-          file_exists($sitePath.'/core/lib/Drupal.php')) {
-            return true;
-        }
-    }
+		/**
+		 * /misc/drupal.js = Drupal 7
+		 * /core/lib/Drupal.php = Drupal 8.
+		 */
+		if (file_exists($sitePath.'/misc/drupal.js') ||
+		  file_exists($sitePath.'/core/lib/Drupal.php')) {
+			return true;
+		}
+	}
 
-    /**
-     * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
-     */
-    public function isStaticFile($sitePath, $siteName, $uri)
-    {
-        $sitePath = $this->addSubdirectory($sitePath);
+	/**
+	 * Determine if the incoming request is for a static file.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string|false
+	 */
+	public function isStaticFile($sitePath, $siteName, $uri)
+	{
+		$sitePath = $this->addSubdirectory($sitePath);
 
-        if (file_exists($sitePath.$uri) &&
-            ! is_dir($sitePath.$uri) &&
-            pathinfo($sitePath.$uri)['extension'] != 'php') {
-            return $sitePath.$uri;
-        }
+		if (file_exists($sitePath.$uri) &&
+			! is_dir($sitePath.$uri) &&
+			pathinfo($sitePath.$uri)['extension'] != 'php') {
+			return $sitePath.$uri;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        $sitePath = $this->addSubdirectory($sitePath);
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		$sitePath = $this->addSubdirectory($sitePath);
 
-        if (! isset($_GET['q']) && ! empty($uri) && $uri !== '/' && strpos($uri, '/jsonapi/') === false) {
-            $_GET['q'] = $uri;
-        }
+		if (! isset($_GET['q']) && ! empty($uri) && $uri !== '/' && strpos($uri, '/jsonapi/') === false) {
+			$_GET['q'] = $uri;
+		}
 
-        $matches = [];
-        if (preg_match('/^\/(.*?)\.php/', $uri, $matches)) {
-            $filename = $matches[0];
-            if (file_exists($sitePath.$filename) && ! is_dir($sitePath.$filename)) {
-                $_SERVER['SCRIPT_FILENAME'] = $sitePath.$filename;
-                $_SERVER['SCRIPT_NAME'] = $filename;
+		$matches = [];
+		if (preg_match('/^\/(.*?)\.php/', $uri, $matches)) {
+			$filename = $matches[0];
+			if (file_exists($sitePath.$filename) && ! is_dir($sitePath.$filename)) {
+				$_SERVER['SCRIPT_FILENAME'] = $sitePath.$filename;
+				$_SERVER['SCRIPT_NAME'] = $filename;
 
-                return $sitePath.$filename;
-            }
-        }
+				return $sitePath.$filename;
+			}
+		}
 
-        // Fallback
-        $_SERVER['SCRIPT_FILENAME'] = $sitePath.'/index.php';
-        $_SERVER['SCRIPT_NAME'] = '/index.php';
+		// Fallback
+		$_SERVER['SCRIPT_FILENAME'] = $sitePath.'/index.php';
+		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
-        return $sitePath.'/index.php';
-    }
+		return $sitePath.'/index.php';
+	}
 
-    /**
-     * Add any matching subdirectory to the site path.
-     */
-    public function addSubdirectory($sitePath)
-    {
-        $paths = array_map(function ($subDir) use ($sitePath) {
-            return "$sitePath/$subDir";
-        }, $this->possibleSubdirectories());
+	/**
+	 * Add any matching subdirectory to the site path.
+	 */
+	public function addSubdirectory($sitePath)
+	{
+		$paths = array_map(function ($subDir) use ($sitePath) {
+			return "$sitePath/$subDir";
+		}, $this->possibleSubdirectories());
 
-        $foundPaths = array_filter($paths, function ($path) {
-            return file_exists($path);
-        });
+		$foundPaths = array_filter($paths, function ($path) {
+			return file_exists($path);
+		});
 
-        // If paths are found, return the first one.
-        if (! empty($foundPaths)) {
-            return array_shift($foundPaths);
-        }
+		// If paths are found, return the first one.
+		if (! empty($foundPaths)) {
+			return array_shift($foundPaths);
+		}
 
-        // If there are no matches, return the original path.
-        return $sitePath;
-    }
+		// If there are no matches, return the original path.
+		return $sitePath;
+	}
 
-    /**
-     * Return an array of possible subdirectories.
-     *
-     * @return array
-     */
-    private function possibleSubdirectories()
-    {
-        return ['docroot', 'public', 'web'];
-    }
+	/**
+	 * Return an array of possible subdirectories.
+	 *
+	 * @return array
+	 */
+	private function possibleSubdirectories()
+	{
+		return ['docroot', 'public', 'web'];
+	}
 }

--- a/cli/drivers/JigsawValetDriver.php
+++ b/cli/drivers/JigsawValetDriver.php
@@ -2,27 +2,27 @@
 
 class JigsawValetDriver extends BasicValetDriver
 {
-    /**
-     * Mutate the incoming URI.
-     *
-     * @param  string  $uri
-     * @return string
-     */
-    public function mutateUri($uri)
-    {
-        return rtrim('/build_local'.$uri, '/');
-    }
+	/**
+	 * Mutate the incoming URI.
+	 *
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function mutateUri($uri)
+	{
+		return rtrim('/build_local'.$uri, '/');
+	}
 
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return void
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return is_dir($sitePath.'/build_local');
-    }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return void
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return is_dir($sitePath.'/build_local');
+	}
 }

--- a/cli/drivers/JoomlaValetDriver.php
+++ b/cli/drivers/JoomlaValetDriver.php
@@ -2,31 +2,31 @@
 
 class JoomlaValetDriver extends BasicValetDriver
 {
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return is_dir($sitePath.'/libraries/joomla');
-    }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return is_dir($sitePath.'/libraries/joomla');
+	}
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        $_SERVER['PHP_SELF'] = $uri;
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		$_SERVER['PHP_SELF'] = $uri;
 
-        return parent::frontControllerPath($sitePath, $siteName, $uri);
-    }
+		return parent::frontControllerPath($sitePath, $siteName, $uri);
+	}
 }

--- a/cli/drivers/KatanaValetDriver.php
+++ b/cli/drivers/KatanaValetDriver.php
@@ -2,27 +2,27 @@
 
 class KatanaValetDriver extends BasicValetDriver
 {
-    /**
-     * Mutate the incoming URI.
-     *
-     * @param  string  $uri
-     * @return string
-     */
-    public function mutateUri($uri)
-    {
-        return rtrim('/public'.$uri, '/');
-    }
+	/**
+	 * Mutate the incoming URI.
+	 *
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function mutateUri($uri)
+	{
+		return rtrim('/public'.$uri, '/');
+	}
 
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return void
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return file_exists($sitePath.'/katana');
-    }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return void
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return file_exists($sitePath.'/katana');
+	}
 }

--- a/cli/drivers/KirbyValetDriver.php
+++ b/cli/drivers/KirbyValetDriver.php
@@ -2,69 +2,69 @@
 
 class KirbyValetDriver extends ValetDriver
 {
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return void
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return is_dir($sitePath.'/kirby');
-    }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return void
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return is_dir($sitePath.'/kirby');
+	}
 
-    /**
-     * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
-     */
-    public function isStaticFile($sitePath, $siteName, $uri)
-    {
-        if ($this->isActualFile($staticFilePath = $sitePath.$uri)) {
-            return $staticFilePath;
-        } elseif ($this->isActualFile($staticFilePath = $sitePath.'/public'.$uri)) {
-            return $staticFilePath;
-        }
+	/**
+	 * Determine if the incoming request is for a static file.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string|false
+	 */
+	public function isStaticFile($sitePath, $siteName, $uri)
+	{
+		if ($this->isActualFile($staticFilePath = $sitePath.$uri)) {
+			return $staticFilePath;
+		} elseif ($this->isActualFile($staticFilePath = $sitePath.'/public'.$uri)) {
+			return $staticFilePath;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        $scriptName = '/index.php';
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		$scriptName = '/index.php';
 
-        if ($this->isActualFile($sitePath.'/index.php')) {
-            $indexPath = $sitePath.'/index.php';
-        }
+		if ($this->isActualFile($sitePath.'/index.php')) {
+			$indexPath = $sitePath.'/index.php';
+		}
 
-        if ($isAboveWebroot = $this->isActualFile($sitePath.'/public/index.php')) {
-            $indexPath = $sitePath.'/public/index.php';
-        }
+		if ($isAboveWebroot = $this->isActualFile($sitePath.'/public/index.php')) {
+			$indexPath = $sitePath.'/public/index.php';
+		}
 
-        if (preg_match('/^\/panel/', $uri) && $this->isActualFile($sitePath.'/panel/index.php')) {
-            $scriptName = '/panel/index.php';
-            $indexPath = $sitePath.'/panel/index.php';
-        }
+		if (preg_match('/^\/panel/', $uri) && $this->isActualFile($sitePath.'/panel/index.php')) {
+			$scriptName = '/panel/index.php';
+			$indexPath = $sitePath.'/panel/index.php';
+		}
 
-        $sitePathPrefix = ($isAboveWebroot) ? $sitePath.'/public' : $sitePath;
+		$sitePathPrefix = ($isAboveWebroot) ? $sitePath.'/public' : $sitePath;
 
-        $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
-        $_SERVER['SCRIPT_NAME'] = $scriptName;
-        $_SERVER['SCRIPT_FILENAME'] = $sitePathPrefix.$scriptName;
+		$_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+		$_SERVER['SCRIPT_NAME'] = $scriptName;
+		$_SERVER['SCRIPT_FILENAME'] = $sitePathPrefix.$scriptName;
 
-        return $indexPath;
-    }
+		return $indexPath;
+	}
 }

--- a/cli/drivers/LaravelValetDriver.php
+++ b/cli/drivers/LaravelValetDriver.php
@@ -2,63 +2,63 @@
 
 class LaravelValetDriver extends ValetDriver
 {
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return file_exists($sitePath.'/public/index.php') &&
-               file_exists($sitePath.'/artisan');
-    }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return file_exists($sitePath.'/public/index.php') &&
+			   file_exists($sitePath.'/artisan');
+	}
 
-    /**
-     * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
-     */
-    public function isStaticFile($sitePath, $siteName, $uri)
-    {
-        if (file_exists($staticFilePath = $sitePath.'/public'.$uri)
-            && is_file($staticFilePath)) {
-            return $staticFilePath;
-        }
+	/**
+	 * Determine if the incoming request is for a static file.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string|false
+	 */
+	public function isStaticFile($sitePath, $siteName, $uri)
+	{
+		if (file_exists($staticFilePath = $sitePath.'/public'.$uri)
+			&& is_file($staticFilePath)) {
+			return $staticFilePath;
+		}
 
-        $storageUri = $uri;
+		$storageUri = $uri;
 
-        if (strpos($uri, '/storage/') === 0) {
-            $storageUri = substr($uri, 8);
-        }
+		if (strpos($uri, '/storage/') === 0) {
+			$storageUri = substr($uri, 8);
+		}
 
-        if ($this->isActualFile($storagePath = $sitePath.'/storage/app/public'.$storageUri)) {
-            return $storagePath;
-        }
+		if ($this->isActualFile($storagePath = $sitePath.'/storage/app/public'.$storageUri)) {
+			return $storagePath;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        // Shortcut for getting the "local" hostname as the HTTP_HOST
-        if (isset($_SERVER['HTTP_X_ORIGINAL_HOST'], $_SERVER['HTTP_X_FORWARDED_HOST'])) {
-            $_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_FORWARDED_HOST'];
-        }
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		// Shortcut for getting the "local" hostname as the HTTP_HOST
+		if (isset($_SERVER['HTTP_X_ORIGINAL_HOST'], $_SERVER['HTTP_X_FORWARDED_HOST'])) {
+			$_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_FORWARDED_HOST'];
+		}
 
-        return $sitePath.'/public/index.php';
-    }
+		return $sitePath.'/public/index.php';
+	}
 }

--- a/cli/drivers/Magento2ValetDriver.php
+++ b/cli/drivers/Magento2ValetDriver.php
@@ -2,161 +2,161 @@
 
 class Magento2ValetDriver extends ValetDriver
 {
-    /**
-     * Holds the MAGE_MODE from app/etc/config.php or $ENV.
-     *
-     * @var string
-     */
-    private $mageMode;
+	/**
+	 * Holds the MAGE_MODE from app/etc/config.php or $ENV.
+	 *
+	 * @var string
+	 */
+	private $mageMode;
 
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return file_exists($sitePath.'/bin/magento') && file_exists($sitePath.'/pub/index.php');
-    }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return file_exists($sitePath.'/bin/magento') && file_exists($sitePath.'/pub/index.php');
+	}
 
-    /**
-     * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
-     */
-    public function isStaticFile($sitePath, $siteName, $uri)
-    {
-        $this->checkMageMode($sitePath);
+	/**
+	 * Determine if the incoming request is for a static file.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string|false
+	 */
+	public function isStaticFile($sitePath, $siteName, $uri)
+	{
+		$this->checkMageMode($sitePath);
 
-        $uri = $this->handleForVersions($uri);
-        $route = parse_url(substr($uri, 1))['path'];
+		$uri = $this->handleForVersions($uri);
+		$route = parse_url(substr($uri, 1))['path'];
 
-        $pub = '';
-        if ('developer' === $this->mageMode) {
-            $pub = 'pub/';
-        }
+		$pub = '';
+		if ('developer' === $this->mageMode) {
+			$pub = 'pub/';
+		}
 
-        if (! $this->isPubDirectory($sitePath, $route, $pub)) {
-            return false;
-        }
+		if (! $this->isPubDirectory($sitePath, $route, $pub)) {
+			return false;
+		}
 
-        $magentoPackagePubDir = $sitePath;
-        if ('developer' !== $this->mageMode) {
-            $magentoPackagePubDir .= '/pub';
-        }
+		$magentoPackagePubDir = $sitePath;
+		if ('developer' !== $this->mageMode) {
+			$magentoPackagePubDir .= '/pub';
+		}
 
-        $file = $magentoPackagePubDir.'/'.$route;
+		$file = $magentoPackagePubDir.'/'.$route;
 
-        if (file_exists($file)) {
-            return $magentoPackagePubDir.$uri;
-        }
+		if (file_exists($file)) {
+			return $magentoPackagePubDir.$uri;
+		}
 
-        if (strpos($route, $pub.'static/') === 0) {
-            $route = preg_replace('#'.$pub.'static/#', '', $route, 1);
-            $_GET['resource'] = $route;
-            include $magentoPackagePubDir.'/'.$pub.'static.php';
-            exit;
-        }
+		if (strpos($route, $pub.'static/') === 0) {
+			$route = preg_replace('#'.$pub.'static/#', '', $route, 1);
+			$_GET['resource'] = $route;
+			include $magentoPackagePubDir.'/'.$pub.'static.php';
+			exit;
+		}
 
-        if (strpos($route, $pub.'media/') === 0) {
-            include $magentoPackagePubDir.'/'.$pub.'get.php';
-            exit;
-        }
+		if (strpos($route, $pub.'media/') === 0) {
+			include $magentoPackagePubDir.'/'.$pub.'get.php';
+			exit;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Rewrite URLs that look like "versions12345/" to remove
-     * the versions12345/ part.
-     *
-     * @param  string  $route
-     * @return string
-     */
-    private function handleForVersions($route)
-    {
-        return preg_replace('/version\d*\//', '', $route);
-    }
+	/**
+	 * Rewrite URLs that look like "versions12345/" to remove
+	 * the versions12345/ part.
+	 *
+	 * @param  string  $route
+	 * @return string
+	 */
+	private function handleForVersions($route)
+	{
+		return preg_replace('/version\d*\//', '', $route);
+	}
 
-    /**
-     * Determine the current MAGE_MODE.
-     *
-     * @param  string  $sitePath
-     */
-    private function checkMageMode($sitePath)
-    {
-        if (null !== $this->mageMode) {
-            // We have already figure out mode, no need to check it again
-            return;
-        }
+	/**
+	 * Determine the current MAGE_MODE.
+	 *
+	 * @param  string  $sitePath
+	 */
+	private function checkMageMode($sitePath)
+	{
+		if (null !== $this->mageMode) {
+			// We have already figure out mode, no need to check it again
+			return;
+		}
 
-        if (! file_exists($sitePath.'/index.php')) {
-            $this->mageMode = 'production'; // Can't use developer mode without index.php in project root
+		if (! file_exists($sitePath.'/index.php')) {
+			$this->mageMode = 'production'; // Can't use developer mode without index.php in project root
 
-            return;
-        }
+			return;
+		}
 
-        $mageConfig = [];
+		$mageConfig = [];
 
-        if (file_exists($sitePath.'/app/etc/env.php')) {
-            $mageConfig = require $sitePath.'/app/etc/env.php';
-        }
+		if (file_exists($sitePath.'/app/etc/env.php')) {
+			$mageConfig = require $sitePath.'/app/etc/env.php';
+		}
 
-        if (array_key_exists('MAGE_MODE', $mageConfig)) {
-            $this->mageMode = $mageConfig['MAGE_MODE'];
-        }
-    }
+		if (array_key_exists('MAGE_MODE', $mageConfig)) {
+			$this->mageMode = $mageConfig['MAGE_MODE'];
+		}
+	}
 
-    /**
-     * Checks to see if route is referencing any directory inside pub. This is a dynamic check so that if any new
-     * directories are added to pub this driver will not need to be updated.
-     *
-     * @param  string  $sitePath
-     * @param  string  $route
-     * @param  string  $pub
-     * @return bool
-     */
-    private function isPubDirectory($sitePath, $route, $pub = '')
-    {
-        $sitePath .= '/pub/';
-        $dirs = glob($sitePath.'*', GLOB_ONLYDIR);
+	/**
+	 * Checks to see if route is referencing any directory inside pub. This is a dynamic check so that if any new
+	 * directories are added to pub this driver will not need to be updated.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $route
+	 * @param  string  $pub
+	 * @return bool
+	 */
+	private function isPubDirectory($sitePath, $route, $pub = '')
+	{
+		$sitePath .= '/pub/';
+		$dirs = glob($sitePath.'*', GLOB_ONLYDIR);
 
-        $dirs = str_replace($sitePath, '', $dirs);
-        foreach ($dirs as $dir) {
-            if (strpos($route, $pub.$dir.'/') === 0) {
-                return true;
-            }
-        }
+		$dirs = str_replace($sitePath, '', $dirs);
+		foreach ($dirs as $dir) {
+			if (strpos($route, $pub.$dir.'/') === 0) {
+				return true;
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        $this->checkMageMode($sitePath);
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		$this->checkMageMode($sitePath);
 
-        if ('developer' === $this->mageMode) {
-            $_SERVER['DOCUMENT_ROOT'] = $sitePath;
+		if ('developer' === $this->mageMode) {
+			$_SERVER['DOCUMENT_ROOT'] = $sitePath;
 
-            return $sitePath.'/index.php';
-        }
+			return $sitePath.'/index.php';
+		}
 
-        $_SERVER['DOCUMENT_ROOT'] = $sitePath.'/pub';
+		$_SERVER['DOCUMENT_ROOT'] = $sitePath.'/pub';
 
-        return $sitePath.'/pub/index.php';
-    }
+		return $sitePath.'/pub/index.php';
+	}
 }

--- a/cli/drivers/NeosValetDriver.php
+++ b/cli/drivers/NeosValetDriver.php
@@ -2,51 +2,51 @@
 
 class NeosValetDriver extends ValetDriver
 {
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return file_exists($sitePath.'/flow') && is_dir($sitePath.'/Web');
-    }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return file_exists($sitePath.'/flow') && is_dir($sitePath.'/Web');
+	}
 
-    /**
-     * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
-     */
-    public function isStaticFile($sitePath, $siteName, $uri)
-    {
-        if ($this->isActualFile($staticFilePath = $sitePath.'/Web'.$uri)) {
-            return $staticFilePath;
-        }
+	/**
+	 * Determine if the incoming request is for a static file.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string|false
+	 */
+	public function isStaticFile($sitePath, $siteName, $uri)
+	{
+		if ($this->isActualFile($staticFilePath = $sitePath.'/Web'.$uri)) {
+			return $staticFilePath;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        putenv('FLOW_CONTEXT=Development');
-        putenv('FLOW_REWRITEURLS=1');
-        $_SERVER['SCRIPT_FILENAME'] = $sitePath.'/Web/index.php';
-        $_SERVER['SCRIPT_NAME'] = '/index.php';
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		putenv('FLOW_CONTEXT=Development');
+		putenv('FLOW_REWRITEURLS=1');
+		$_SERVER['SCRIPT_FILENAME'] = $sitePath.'/Web/index.php';
+		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
-        return $sitePath.'/Web/index.php';
-    }
+		return $sitePath.'/Web/index.php';
+	}
 }

--- a/cli/drivers/SculpinValetDriver.php
+++ b/cli/drivers/SculpinValetDriver.php
@@ -2,56 +2,56 @@
 
 class SculpinValetDriver extends BasicValetDriver
 {
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return $this->isModernSculpinProject($sitePath) ||
-            $this->isLegacySculpinProject($sitePath);
-    }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return $this->isModernSculpinProject($sitePath) ||
+			$this->isLegacySculpinProject($sitePath);
+	}
 
-    private function isModernSculpinProject($sitePath)
-    {
-        return is_dir($sitePath.'/source') &&
-            is_dir($sitePath.'/output_dev') &&
-            $this->composerRequiresSculpin($sitePath);
-    }
+	private function isModernSculpinProject($sitePath)
+	{
+		return is_dir($sitePath.'/source') &&
+			is_dir($sitePath.'/output_dev') &&
+			$this->composerRequiresSculpin($sitePath);
+	}
 
-    private function isLegacySculpinProject($sitePath)
-    {
-        return is_dir($sitePath.'/.sculpin');
-    }
+	private function isLegacySculpinProject($sitePath)
+	{
+		return is_dir($sitePath.'/.sculpin');
+	}
 
-    private function composerRequiresSculpin($sitePath)
-    {
-        if (! file_exists($sitePath.'/composer.json')) {
-            return false;
-        }
+	private function composerRequiresSculpin($sitePath)
+	{
+		if (! file_exists($sitePath.'/composer.json')) {
+			return false;
+		}
 
-        $composer_json_source = file_get_contents($sitePath.'/composer.json');
-        $composer_json = json_decode($composer_json_source, true);
+		$composer_json_source = file_get_contents($sitePath.'/composer.json');
+		$composer_json = json_decode($composer_json_source, true);
 
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            return false;
-        }
+		if (json_last_error() !== JSON_ERROR_NONE) {
+			return false;
+		}
 
-        return isset($composer_json['require']['sculpin/sculpin']);
-    }
+		return isset($composer_json['require']['sculpin/sculpin']);
+	}
 
-    /**
-     * Mutate the incoming URI.
-     *
-     * @param  string  $uri
-     * @return string
-     */
-    public function mutateUri($uri)
-    {
-        return rtrim('/output_dev'.$uri, '/');
-    }
+	/**
+	 * Mutate the incoming URI.
+	 *
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function mutateUri($uri)
+	{
+		return rtrim('/output_dev'.$uri, '/');
+	}
 }

--- a/cli/drivers/StatamicV1ValetDriver.php
+++ b/cli/drivers/StatamicV1ValetDriver.php
@@ -2,67 +2,67 @@
 
 class StatamicV1ValetDriver extends ValetDriver
 {
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return file_exists($sitePath.'/_app/core/statamic.php');
-    }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return file_exists($sitePath.'/_app/core/statamic.php');
+	}
 
-    /**
-     * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
-     */
-    public function isStaticFile($sitePath, $siteName, $uri)
-    {
-        if (strpos($uri, '/_add-ons') === 0 || strpos($uri, '/_app') === 0 || strpos($uri, '/_content') === 0 ||
-            strpos($uri, '/_cache') === 0 || strpos($uri, '/_config') === 0 || strpos($uri, '/_logs') === 0 ||
-            $uri === '/admin'
-        ) {
-            return false;
-        }
+	/**
+	 * Determine if the incoming request is for a static file.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string|false
+	 */
+	public function isStaticFile($sitePath, $siteName, $uri)
+	{
+		if (strpos($uri, '/_add-ons') === 0 || strpos($uri, '/_app') === 0 || strpos($uri, '/_content') === 0 ||
+			strpos($uri, '/_cache') === 0 || strpos($uri, '/_config') === 0 || strpos($uri, '/_logs') === 0 ||
+			$uri === '/admin'
+		) {
+			return false;
+		}
 
-        if ($this->isActualFile($staticFilePath = $sitePath.$uri)) {
-            return $staticFilePath;
-        }
+		if ($this->isActualFile($staticFilePath = $sitePath.$uri)) {
+			return $staticFilePath;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        if (strpos($uri, '/admin.php') === 0) {
-            $_SERVER['SCRIPT_NAME'] = '/admin.php';
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		if (strpos($uri, '/admin.php') === 0) {
+			$_SERVER['SCRIPT_NAME'] = '/admin.php';
 
-            return $sitePath.'/admin.php';
-        }
+			return $sitePath.'/admin.php';
+		}
 
-        if ($uri === '/admin') {
-            $_SERVER['SCRIPT_NAME'] = '/admin/index.php';
+		if ($uri === '/admin') {
+			$_SERVER['SCRIPT_NAME'] = '/admin/index.php';
 
-            return $sitePath.'/admin/index.php';
-        }
+			return $sitePath.'/admin/index.php';
+		}
 
-        $_SERVER['SCRIPT_NAME'] = '/index.php';
+		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
-        return $sitePath.'/index.php';
-    }
+		return $sitePath.'/index.php';
+	}
 }

--- a/cli/drivers/StatamicValetDriver.php
+++ b/cli/drivers/StatamicValetDriver.php
@@ -2,145 +2,145 @@
 
 class StatamicValetDriver extends ValetDriver
 {
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return is_dir($sitePath.'/statamic');
-    }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return is_dir($sitePath.'/statamic');
+	}
 
-    /**
-     * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
-     */
-    public function isStaticFile($sitePath, $siteName, $uri)
-    {
-        if (strpos($uri, '/site') === 0 && strpos($uri, '/site/themes') !== 0) {
-            return false;
-        } elseif (strpos($uri, '/local') === 0 || strpos($uri, '/statamic') === 0) {
-            return false;
-        } elseif ($this->isActualFile($staticFilePath = $sitePath.$uri)) {
-            return $staticFilePath;
-        } elseif ($this->isActualFile($staticFilePath = $sitePath.'/public'.$uri)) {
-            return $staticFilePath;
-        }
+	/**
+	 * Determine if the incoming request is for a static file.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string|false
+	 */
+	public function isStaticFile($sitePath, $siteName, $uri)
+	{
+		if (strpos($uri, '/site') === 0 && strpos($uri, '/site/themes') !== 0) {
+			return false;
+		} elseif (strpos($uri, '/local') === 0 || strpos($uri, '/statamic') === 0) {
+			return false;
+		} elseif ($this->isActualFile($staticFilePath = $sitePath.$uri)) {
+			return $staticFilePath;
+		} elseif ($this->isActualFile($staticFilePath = $sitePath.'/public'.$uri)) {
+			return $staticFilePath;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        if ($_SERVER['REQUEST_METHOD'] === 'GET' && $this->isActualFile($staticPath = $this->getStaticPath($sitePath))) {
-            return $staticPath;
-        }
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		if ($_SERVER['REQUEST_METHOD'] === 'GET' && $this->isActualFile($staticPath = $this->getStaticPath($sitePath))) {
+			return $staticPath;
+		}
 
-        if ($uri === '/installer.php') {
-            return $sitePath.'/installer.php';
-        }
+		if ($uri === '/installer.php') {
+			return $sitePath.'/installer.php';
+		}
 
-        $scriptName = '/index.php';
+		$scriptName = '/index.php';
 
-        if ($this->isActualFile($sitePath.'/index.php')) {
-            $indexPath = $sitePath.'/index.php';
-        }
+		if ($this->isActualFile($sitePath.'/index.php')) {
+			$indexPath = $sitePath.'/index.php';
+		}
 
-        if ($isAboveWebroot = $this->isActualFile($sitePath.'/public/index.php')) {
-            $indexPath = $sitePath.'/public/index.php';
-        }
+		if ($isAboveWebroot = $this->isActualFile($sitePath.'/public/index.php')) {
+			$indexPath = $sitePath.'/public/index.php';
+		}
 
-        $sitePathPrefix = ($isAboveWebroot) ? $sitePath.'/public' : $sitePath;
+		$sitePathPrefix = ($isAboveWebroot) ? $sitePath.'/public' : $sitePath;
 
-        if ($locale = $this->getUriLocale($uri)) {
-            if ($this->isActualFile($localeIndexPath = $sitePathPrefix.'/'.$locale.'/index.php')) {
-                // Force trailing slashes on locale roots.
-                if ($uri === '/'.$locale) {
-                    header('Location: '.$uri.'/');
-                    exit;
-                }
+		if ($locale = $this->getUriLocale($uri)) {
+			if ($this->isActualFile($localeIndexPath = $sitePathPrefix.'/'.$locale.'/index.php')) {
+				// Force trailing slashes on locale roots.
+				if ($uri === '/'.$locale) {
+					header('Location: '.$uri.'/');
+					exit;
+				}
 
-                $indexPath = $localeIndexPath;
-                $scriptName = '/'.$locale.'/index.php';
-            }
-        }
+				$indexPath = $localeIndexPath;
+				$scriptName = '/'.$locale.'/index.php';
+			}
+		}
 
-        $_SERVER['SCRIPT_NAME'] = $scriptName;
-        $_SERVER['SCRIPT_FILENAME'] = $sitePathPrefix.$scriptName;
+		$_SERVER['SCRIPT_NAME'] = $scriptName;
+		$_SERVER['SCRIPT_FILENAME'] = $sitePathPrefix.$scriptName;
 
-        return $indexPath;
-    }
+		return $indexPath;
+	}
 
-    /**
-     * Get the locale from this URI.
-     *
-     * @param  string  $uri
-     * @return string|null
-     */
-    public function getUriLocale($uri)
-    {
-        $parts = explode('/', $uri);
-        $locale = $parts[1];
+	/**
+	 * Get the locale from this URI.
+	 *
+	 * @param  string  $uri
+	 * @return string|null
+	 */
+	public function getUriLocale($uri)
+	{
+		$parts = explode('/', $uri);
+		$locale = $parts[1];
 
-        if (count($parts) < 2 || ! in_array($locale, $this->getLocales())) {
-            return;
-        }
+		if (count($parts) < 2 || ! in_array($locale, $this->getLocales())) {
+			return;
+		}
 
-        return $locale;
-    }
+		return $locale;
+	}
 
-    /**
-     * Get the list of possible locales used in the first segment of a URI.
-     *
-     * @return array
-     */
-    public function getLocales()
-    {
-        return [
-            'af', 'ax', 'al', 'dz', 'as', 'ad', 'ao', 'ai', 'aq', 'ag', 'ar', 'am', 'aw', 'au', 'at', 'az', 'bs', 'bh',
-            'bd', 'bb', 'by', 'be', 'bz', 'bj', 'bm', 'bt', 'bo', 'bq', 'ba', 'bw', 'bv', 'br', 'io', 'bn', 'bg', 'bf',
-            'bi', 'cv', 'kh', 'cm', 'ca', 'ky', 'cf', 'td', 'cl', 'cn', 'cx', 'cc', 'co', 'km', 'cg', 'cd', 'ck', 'cr',
-            'ci', 'hr', 'cu', 'cw', 'cy', 'cz', 'dk', 'dj', 'dm', 'do', 'ec', 'eg', 'sv', 'gq', 'er', 'ee', 'et', 'fk',
-            'fo', 'fj', 'fi', 'fr', 'gf', 'pf', 'tf', 'ga', 'gm', 'ge', 'de', 'gh', 'gi', 'gr', 'gl', 'gd', 'gp', 'gu',
-            'gt', 'gg', 'gn', 'gw', 'gy', 'ht', 'hm', 'va', 'hn', 'hk', 'hu', 'is', 'in', 'id', 'ir', 'iq', 'ie', 'im',
-            'il', 'it', 'jm', 'jp', 'je', 'jo', 'kz', 'ke', 'ki', 'kp', 'kr', 'kw', 'kg', 'la', 'lv', 'lb', 'ls', 'lr',
-            'ly', 'li', 'lt', 'lu', 'mo', 'mk', 'mg', 'mw', 'my', 'mv', 'ml', 'mt', 'mh', 'mq', 'mr', 'mu', 'yt', 'mx',
-            'fm', 'md', 'mc', 'mn', 'me', 'ms', 'ma', 'mz', 'mm', 'na', 'nr', 'np', 'nl', 'nc', 'nz', 'ni', 'ne', 'ng',
-            'nu', 'nf', 'mp', 'no', 'om', 'pk', 'pw', 'ps', 'pa', 'pg', 'py', 'pe', 'ph', 'pn', 'pl', 'pt', 'pr', 'qa',
-            're', 'ro', 'ru', 'rw', 'bl', 'sh', 'kn', 'lc', 'mf', 'pm', 'vc', 'ws', 'sm', 'st', 'sa', 'sn', 'rs', 'sc',
-            'sl', 'sg', 'sx', 'sk', 'si', 'sb', 'so', 'za', 'gs', 'ss', 'es', 'lk', 'sd', 'sr', 'sj', 'sz', 'se', 'ch',
-            'sy', 'tw', 'tj', 'tz', 'th', 'tl', 'tg', 'tk', 'to', 'tt', 'tn', 'tr', 'tm', 'tc', 'tv', 'ug', 'ua', 'ae',
-            'gb', 'us', 'um', 'uy', 'uz', 'vu', 've', 'vn', 'vg', 'vi', 'wf', 'eh', 'ye', 'zm', 'zw', 'en', 'zh',
-        ];
-    }
+	/**
+	 * Get the list of possible locales used in the first segment of a URI.
+	 *
+	 * @return array
+	 */
+	public function getLocales()
+	{
+		return [
+			'af', 'ax', 'al', 'dz', 'as', 'ad', 'ao', 'ai', 'aq', 'ag', 'ar', 'am', 'aw', 'au', 'at', 'az', 'bs', 'bh',
+			'bd', 'bb', 'by', 'be', 'bz', 'bj', 'bm', 'bt', 'bo', 'bq', 'ba', 'bw', 'bv', 'br', 'io', 'bn', 'bg', 'bf',
+			'bi', 'cv', 'kh', 'cm', 'ca', 'ky', 'cf', 'td', 'cl', 'cn', 'cx', 'cc', 'co', 'km', 'cg', 'cd', 'ck', 'cr',
+			'ci', 'hr', 'cu', 'cw', 'cy', 'cz', 'dk', 'dj', 'dm', 'do', 'ec', 'eg', 'sv', 'gq', 'er', 'ee', 'et', 'fk',
+			'fo', 'fj', 'fi', 'fr', 'gf', 'pf', 'tf', 'ga', 'gm', 'ge', 'de', 'gh', 'gi', 'gr', 'gl', 'gd', 'gp', 'gu',
+			'gt', 'gg', 'gn', 'gw', 'gy', 'ht', 'hm', 'va', 'hn', 'hk', 'hu', 'is', 'in', 'id', 'ir', 'iq', 'ie', 'im',
+			'il', 'it', 'jm', 'jp', 'je', 'jo', 'kz', 'ke', 'ki', 'kp', 'kr', 'kw', 'kg', 'la', 'lv', 'lb', 'ls', 'lr',
+			'ly', 'li', 'lt', 'lu', 'mo', 'mk', 'mg', 'mw', 'my', 'mv', 'ml', 'mt', 'mh', 'mq', 'mr', 'mu', 'yt', 'mx',
+			'fm', 'md', 'mc', 'mn', 'me', 'ms', 'ma', 'mz', 'mm', 'na', 'nr', 'np', 'nl', 'nc', 'nz', 'ni', 'ne', 'ng',
+			'nu', 'nf', 'mp', 'no', 'om', 'pk', 'pw', 'ps', 'pa', 'pg', 'py', 'pe', 'ph', 'pn', 'pl', 'pt', 'pr', 'qa',
+			're', 'ro', 'ru', 'rw', 'bl', 'sh', 'kn', 'lc', 'mf', 'pm', 'vc', 'ws', 'sm', 'st', 'sa', 'sn', 'rs', 'sc',
+			'sl', 'sg', 'sx', 'sk', 'si', 'sb', 'so', 'za', 'gs', 'ss', 'es', 'lk', 'sd', 'sr', 'sj', 'sz', 'se', 'ch',
+			'sy', 'tw', 'tj', 'tz', 'th', 'tl', 'tg', 'tk', 'to', 'tt', 'tn', 'tr', 'tm', 'tc', 'tv', 'ug', 'ua', 'ae',
+			'gb', 'us', 'um', 'uy', 'uz', 'vu', 've', 'vn', 'vg', 'vi', 'wf', 'eh', 'ye', 'zm', 'zw', 'en', 'zh',
+		];
+	}
 
-    /**
-     * Get the path to a statically cached page.
-     *
-     * @param  string  $sitePath
-     * @return string
-     */
-    protected function getStaticPath($sitePath)
-    {
-        $parts = parse_url($_SERVER['REQUEST_URI']);
-        $query = isset($parts['query']) ? $parts['query'] : '';
+	/**
+	 * Get the path to a statically cached page.
+	 *
+	 * @param  string  $sitePath
+	 * @return string
+	 */
+	protected function getStaticPath($sitePath)
+	{
+		$parts = parse_url($_SERVER['REQUEST_URI']);
+		$query = isset($parts['query']) ? $parts['query'] : '';
 
-        return $sitePath.'/static'.$parts['path'].'_'.$query.'.html';
-    }
+		return $sitePath.'/static'.$parts['path'].'_'.$query.'.html';
+	}
 }

--- a/cli/drivers/SymfonyValetDriver.php
+++ b/cli/drivers/SymfonyValetDriver.php
@@ -2,56 +2,56 @@
 
 class SymfonyValetDriver extends ValetDriver
 {
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return (file_exists($sitePath.'/web/app_dev.php') || file_exists($sitePath.'/web/app.php')) &&
-               (file_exists($sitePath.'/app/AppKernel.php')) || (file_exists($sitePath.'/public/index.php')) &&
-               (file_exists($sitePath.'/src/Kernel.php'));
-    }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return (file_exists($sitePath.'/web/app_dev.php') || file_exists($sitePath.'/web/app.php')) &&
+			   (file_exists($sitePath.'/app/AppKernel.php')) || (file_exists($sitePath.'/public/index.php')) &&
+			   (file_exists($sitePath.'/src/Kernel.php'));
+	}
 
-    /**
-     * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
-     */
-    public function isStaticFile($sitePath, $siteName, $uri)
-    {
-        if ($this->isActualFile($staticFilePath = $sitePath.'/web/'.$uri)) {
-            return $staticFilePath;
-        } elseif ($this->isActualFile($staticFilePath = $sitePath.'/public/'.$uri)) {
-            return $staticFilePath;
-        }
+	/**
+	 * Determine if the incoming request is for a static file.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string|false
+	 */
+	public function isStaticFile($sitePath, $siteName, $uri)
+	{
+		if ($this->isActualFile($staticFilePath = $sitePath.'/web/'.$uri)) {
+			return $staticFilePath;
+		} elseif ($this->isActualFile($staticFilePath = $sitePath.'/public/'.$uri)) {
+			return $staticFilePath;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        if (file_exists($frontControllerPath = $sitePath.'/web/app_dev.php')) {
-            return $frontControllerPath;
-        } elseif (file_exists($frontControllerPath = $sitePath.'/web/app.php')) {
-            return $frontControllerPath;
-        } elseif (file_exists($frontControllerPath = $sitePath.'/public/index.php')) {
-            return $frontControllerPath;
-        }
-    }
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		if (file_exists($frontControllerPath = $sitePath.'/web/app_dev.php')) {
+			return $frontControllerPath;
+		} elseif (file_exists($frontControllerPath = $sitePath.'/web/app.php')) {
+			return $frontControllerPath;
+		} elseif (file_exists($frontControllerPath = $sitePath.'/public/index.php')) {
+			return $frontControllerPath;
+		}
+	}
 }

--- a/cli/drivers/Typo3ValetDriver.php
+++ b/cli/drivers/Typo3ValetDriver.php
@@ -7,181 +7,181 @@
  */
 class Typo3ValetDriver extends ValetDriver
 {
-    /*
-    |--------------------------------------------------------------------------
-    | Document Root Subdirectory
-    |--------------------------------------------------------------------------
-    |
-    | This subdirectory contains the public server resources, such as the
-    | index.php, the typo3 and fileadmin system directories. Change it
-    | to '', if you don't use a subdirectory but valet link directly.
-    |
-    */
-    protected $documentRoot = '/web';
+	/*
+	|--------------------------------------------------------------------------
+	| Document Root Subdirectory
+	|--------------------------------------------------------------------------
+	|
+	| This subdirectory contains the public server resources, such as the
+	| index.php, the typo3 and fileadmin system directories. Change it
+	| to '', if you don't use a subdirectory but valet link directly.
+	|
+	*/
+	protected $documentRoot = '/web';
 
-    /*
-    |--------------------------------------------------------------------------
-    | Forbidden URI Patterns
-    |--------------------------------------------------------------------------
-    |
-    | All of these patterns won't be accessible from your web server. Instead,
-    | the server will throw a 403 forbidden response, if you try to access
-    | these files via the HTTP layer. Use regex syntax here and escape @.
-    |
-    */
-    protected $forbiddenUriPatterns = [
-        '_(recycler|temp)_/',
-        '^/(typo3conf/ext|typo3/sysext|typo3/ext)/[^/]+/(Resources/Private|Tests)/',
-        '^/typo3/.+\.map$',
-        '^/typo3temp/var/',
-        '\.(htaccess|gitkeep|gitignore)$',
-    ];
+	/*
+	|--------------------------------------------------------------------------
+	| Forbidden URI Patterns
+	|--------------------------------------------------------------------------
+	|
+	| All of these patterns won't be accessible from your web server. Instead,
+	| the server will throw a 403 forbidden response, if you try to access
+	| these files via the HTTP layer. Use regex syntax here and escape @.
+	|
+	*/
+	protected $forbiddenUriPatterns = [
+		'_(recycler|temp)_/',
+		'^/(typo3conf/ext|typo3/sysext|typo3/ext)/[^/]+/(Resources/Private|Tests)/',
+		'^/typo3/.+\.map$',
+		'^/typo3temp/var/',
+		'\.(htaccess|gitkeep|gitignore)$',
+	];
 
-    /**
-     * Determine if the driver serves the request. For TYPO3, this is the
-     * case, if a folder called "typo3" is present in the document root.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        $typo3Dir = $sitePath.$this->documentRoot.'/typo3';
+	/**
+	 * Determine if the driver serves the request. For TYPO3, this is the
+	 * case, if a folder called "typo3" is present in the document root.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		$typo3Dir = $sitePath.$this->documentRoot.'/typo3';
 
-        return file_exists($typo3Dir) && is_dir($typo3Dir);
-    }
+		return file_exists($typo3Dir) && is_dir($typo3Dir);
+	}
 
-    /**
-     * Determine if the incoming request is for a static file. That is, it is
-     * no PHP script file and the URI points to a valid file (no folder) on
-     * the disk. Access to those static files will be authorized.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
-     */
-    public function isStaticFile($sitePath, $siteName, $uri)
-    {
-        // May the file contains a cache busting version string like filename.12345678.css
-        // If that is the case, the file cannot be found on disk, so remove the version
-        // identifier before retrying below.
-        if (! $this->isActualFile($filePath = $sitePath.$this->documentRoot.$uri)) {
-            $uri = preg_replace("@^(.+)\.(\d+)\.(js|css|png|jpg|gif|gzip)$@", '$1.$3', $uri);
-        }
+	/**
+	 * Determine if the incoming request is for a static file. That is, it is
+	 * no PHP script file and the URI points to a valid file (no folder) on
+	 * the disk. Access to those static files will be authorized.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string|false
+	 */
+	public function isStaticFile($sitePath, $siteName, $uri)
+	{
+		// May the file contains a cache busting version string like filename.12345678.css
+		// If that is the case, the file cannot be found on disk, so remove the version
+		// identifier before retrying below.
+		if (! $this->isActualFile($filePath = $sitePath.$this->documentRoot.$uri)) {
+			$uri = preg_replace("@^(.+)\.(\d+)\.(js|css|png|jpg|gif|gzip)$@", '$1.$3', $uri);
+		}
 
-        // Now that any possible version string is cleared from the filename, the resulting
-        // URI should be a valid file on disc. So assemble the absolut file name with the
-        // same schema as above and if it exists, authorize access and return its path.
-        if ($this->isActualFile($filePath = $sitePath.$this->documentRoot.$uri)) {
-            return $this->isAccessAuthorized($uri) ? $filePath : false;
-        }
+		// Now that any possible version string is cleared from the filename, the resulting
+		// URI should be a valid file on disc. So assemble the absolut file name with the
+		// same schema as above and if it exists, authorize access and return its path.
+		if ($this->isActualFile($filePath = $sitePath.$this->documentRoot.$uri)) {
+			return $this->isAccessAuthorized($uri) ? $filePath : false;
+		}
 
-        // This file cannot be found in the current project and thus cannot be served.
-        return false;
-    }
+		// This file cannot be found in the current project and thus cannot be served.
+		return false;
+	}
 
-    /**
-     * Determines if the given URI is blacklisted so that access is prevented.
-     *
-     * @param  string  $uri
-     * @return bool
-     */
-    private function isAccessAuthorized($uri)
-    {
-        foreach ($this->forbiddenUriPatterns as $forbiddenUriPattern) {
-            if (preg_match("@$forbiddenUriPattern@", $uri)) {
-                return false;
-            }
-        }
+	/**
+	 * Determines if the given URI is blacklisted so that access is prevented.
+	 *
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	private function isAccessAuthorized($uri)
+	{
+		foreach ($this->forbiddenUriPatterns as $forbiddenUriPattern) {
+			if (preg_match("@$forbiddenUriPattern@", $uri)) {
+				return false;
+			}
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     * This can be the currently requested PHP script, a folder that
-     * contains an index.php or the global index.php otherwise.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        // without modifying the URI, redirect if necessary
-        $this->handleRedirectBackendShorthandUris($uri);
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 * This can be the currently requested PHP script, a folder that
+	 * contains an index.php or the global index.php otherwise.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		// without modifying the URI, redirect if necessary
+		$this->handleRedirectBackendShorthandUris($uri);
 
-        // from now on, remove trailing / for convenience for all the following join operations
-        $uri = rtrim($uri, '/');
+		// from now on, remove trailing / for convenience for all the following join operations
+		$uri = rtrim($uri, '/');
 
-        // try to find the responsible script file for the requested folder / script URI
-        if (file_exists($absoluteFilePath = $sitePath.$this->documentRoot.$uri)) {
-            if (is_dir($absoluteFilePath)) {
-                if (file_exists($absoluteFilePath.'/index.php')) {
-                    // this folder can be served by index.php
-                    return $this->serveScript($sitePath, $siteName, $uri.'/index.php');
-                }
+		// try to find the responsible script file for the requested folder / script URI
+		if (file_exists($absoluteFilePath = $sitePath.$this->documentRoot.$uri)) {
+			if (is_dir($absoluteFilePath)) {
+				if (file_exists($absoluteFilePath.'/index.php')) {
+					// this folder can be served by index.php
+					return $this->serveScript($sitePath, $siteName, $uri.'/index.php');
+				}
 
-                if (file_exists($absoluteFilePath.'/index.html')) {
-                    // this folder can be served by index.html
-                    return $absoluteFilePath.'/index.html';
-                }
-            } elseif (pathinfo($absoluteFilePath, PATHINFO_EXTENSION) === 'php') {
-                // this file can be served directly
-                return $this->serveScript($sitePath, $siteName, $uri);
-            }
-        }
+				if (file_exists($absoluteFilePath.'/index.html')) {
+					// this folder can be served by index.html
+					return $absoluteFilePath.'/index.html';
+				}
+			} elseif (pathinfo($absoluteFilePath, PATHINFO_EXTENSION) === 'php') {
+				// this file can be served directly
+				return $this->serveScript($sitePath, $siteName, $uri);
+			}
+		}
 
-        // the global index.php will handle all other cases
-        return $this->serveScript($sitePath, $siteName, '/index.php');
-    }
+		// the global index.php will handle all other cases
+		return $this->serveScript($sitePath, $siteName, '/index.php');
+	}
 
-    /**
-     * Direct access to installtool via domain.dev/typo3/install/ will be redirected to
-     * sysext install script. domain.dev/typo3 will be redirected to /typo3/, because
-     * the generated JavaScript URIs on the login screen would be broken on /typo3.
-     *
-     * @param  string  $uri
-     */
-    private function handleRedirectBackendShorthandUris($uri)
-    {
-        if (rtrim($uri, '/') === '/typo3/install') {
-            header('Location: /typo3/sysext/install/Start/Install.php');
-            exit();
-        }
+	/**
+	 * Direct access to installtool via domain.dev/typo3/install/ will be redirected to
+	 * sysext install script. domain.dev/typo3 will be redirected to /typo3/, because
+	 * the generated JavaScript URIs on the login screen would be broken on /typo3.
+	 *
+	 * @param  string  $uri
+	 */
+	private function handleRedirectBackendShorthandUris($uri)
+	{
+		if (rtrim($uri, '/') === '/typo3/install') {
+			header('Location: /typo3/sysext/install/Start/Install.php');
+			exit();
+		}
 
-        if ($uri === '/typo3') {
-            header('Location: /typo3/');
-            exit();
-        }
-    }
+		if ($uri === '/typo3') {
+			header('Location: /typo3/');
+			exit();
+		}
+	}
 
-    /**
-     * Configures the $_SERVER globals for serving the script at
-     * the specified URI and returns it absolute file path.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @param  string  $script
-     * @return string
-     */
-    private function serveScript($sitePath, $siteName, $uri)
-    {
-        $docroot = $sitePath.$this->documentRoot;
-        $abspath = $docroot.$uri;
+	/**
+	 * Configures the $_SERVER globals for serving the script at
+	 * the specified URI and returns it absolute file path.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @param  string  $script
+	 * @return string
+	 */
+	private function serveScript($sitePath, $siteName, $uri)
+	{
+		$docroot = $sitePath.$this->documentRoot;
+		$abspath = $docroot.$uri;
 
-        $_SERVER['SERVER_NAME'] = $siteName.'.dev';
-        $_SERVER['DOCUMENT_ROOT'] = $docroot;
-        $_SERVER['DOCUMENT_URI'] = $uri;
-        $_SERVER['SCRIPT_FILENAME'] = $abspath;
-        $_SERVER['SCRIPT_NAME'] = $uri;
-        $_SERVER['PHP_SELF'] = $uri;
+		$_SERVER['SERVER_NAME'] = $siteName.'.dev';
+		$_SERVER['DOCUMENT_ROOT'] = $docroot;
+		$_SERVER['DOCUMENT_URI'] = $uri;
+		$_SERVER['SCRIPT_FILENAME'] = $abspath;
+		$_SERVER['SCRIPT_NAME'] = $uri;
+		$_SERVER['PHP_SELF'] = $uri;
 
-        return $abspath;
-    }
+		return $abspath;
+	}
 }

--- a/cli/drivers/ValetDriver.php
+++ b/cli/drivers/ValetDriver.php
@@ -2,214 +2,214 @@
 
 abstract class ValetDriver
 {
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    abstract public function serves($sitePath, $siteName, $uri);
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	abstract public function serves($sitePath, $siteName, $uri);
 
-    /**
-     * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
-     */
-    abstract public function isStaticFile($sitePath, $siteName, $uri);
+	/**
+	 * Determine if the incoming request is for a static file.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string|false
+	 */
+	abstract public function isStaticFile($sitePath, $siteName, $uri);
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    abstract public function frontControllerPath($sitePath, $siteName, $uri);
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	abstract public function frontControllerPath($sitePath, $siteName, $uri);
 
-    /**
-     * Find a driver that can serve the incoming request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return ValetDriver|null
-     */
-    public static function assign($sitePath, $siteName, $uri)
-    {
-        $drivers = [];
+	/**
+	 * Find a driver that can serve the incoming request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return ValetDriver|null
+	 */
+	public static function assign($sitePath, $siteName, $uri)
+	{
+		$drivers = [];
 
-        if ($customSiteDriver = static::customSiteDriver($sitePath)) {
-            $drivers[] = $customSiteDriver;
-        }
+		if ($customSiteDriver = static::customSiteDriver($sitePath)) {
+			$drivers[] = $customSiteDriver;
+		}
 
-        $drivers = array_merge($drivers, static::driversIn(VALET_HOME_PATH.'/Drivers'));
+		$drivers = array_merge($drivers, static::driversIn(VALET_HOME_PATH.'/Drivers'));
 
-        $drivers[] = 'LaravelValetDriver';
+		$drivers[] = 'LaravelValetDriver';
 
-        $drivers[] = 'WordPressValetDriver';
-        $drivers[] = 'BedrockValetDriver';
-        $drivers[] = 'ContaoValetDriver';
-        $drivers[] = 'SymfonyValetDriver';
-        $drivers[] = 'CraftValetDriver';
-        $drivers[] = 'StatamicValetDriver';
-        $drivers[] = 'StatamicV1ValetDriver';
-        $drivers[] = 'CakeValetDriver';
-        $drivers[] = 'SculpinValetDriver';
-        $drivers[] = 'JigsawValetDriver';
-        $drivers[] = 'KirbyValetDriver';
-        $drivers[] = 'KatanaValetDriver';
-        $drivers[] = 'JoomlaValetDriver';
-        $drivers[] = 'DrupalValetDriver';
-        $drivers[] = 'Concrete5ValetDriver';
-        $drivers[] = 'Typo3ValetDriver';
-        $drivers[] = 'NeosValetDriver';
-        $drivers[] = 'Magento2ValetDriver';
+		$drivers[] = 'WordPressValetDriver';
+		$drivers[] = 'BedrockValetDriver';
+		$drivers[] = 'ContaoValetDriver';
+		$drivers[] = 'SymfonyValetDriver';
+		$drivers[] = 'CraftValetDriver';
+		$drivers[] = 'StatamicValetDriver';
+		$drivers[] = 'StatamicV1ValetDriver';
+		$drivers[] = 'CakeValetDriver';
+		$drivers[] = 'SculpinValetDriver';
+		$drivers[] = 'JigsawValetDriver';
+		$drivers[] = 'KirbyValetDriver';
+		$drivers[] = 'KatanaValetDriver';
+		$drivers[] = 'JoomlaValetDriver';
+		$drivers[] = 'DrupalValetDriver';
+		$drivers[] = 'Concrete5ValetDriver';
+		$drivers[] = 'Typo3ValetDriver';
+		$drivers[] = 'NeosValetDriver';
+		$drivers[] = 'Magento2ValetDriver';
 
-        $drivers[] = 'BasicValetDriver';
+		$drivers[] = 'BasicValetDriver';
 
-        foreach ($drivers as $driver) {
-            $driver = new $driver();
+		foreach ($drivers as $driver) {
+			$driver = new $driver();
 
-            if ($driver->serves($sitePath, $siteName, $driver->mutateUri($uri))) {
-                return $driver;
-            }
-        }
-    }
+			if ($driver->serves($sitePath, $siteName, $driver->mutateUri($uri))) {
+				return $driver;
+			}
+		}
+	}
 
-    /**
-     * Get the custom driver class from the site path, if one exists.
-     *
-     * @param  string  $sitePath
-     * @return string
-     */
-    public static function customSiteDriver($sitePath)
-    {
-        if (! file_exists($sitePath.'/LocalValetDriver.php')) {
-            return;
-        }
+	/**
+	 * Get the custom driver class from the site path, if one exists.
+	 *
+	 * @param  string  $sitePath
+	 * @return string
+	 */
+	public static function customSiteDriver($sitePath)
+	{
+		if (! file_exists($sitePath.'/LocalValetDriver.php')) {
+			return;
+		}
 
-        require_once $sitePath.'/LocalValetDriver.php';
+		require_once $sitePath.'/LocalValetDriver.php';
 
-        return 'LocalValetDriver';
-    }
+		return 'LocalValetDriver';
+	}
 
-    /**
-     * Get all of the driver classes in a given path.
-     *
-     * @param  string  $path
-     * @return array
-     */
-    public static function driversIn($path)
-    {
-        if (! is_dir($path)) {
-            return [];
-        }
+	/**
+	 * Get all of the driver classes in a given path.
+	 *
+	 * @param  string  $path
+	 * @return array
+	 */
+	public static function driversIn($path)
+	{
+		if (! is_dir($path)) {
+			return [];
+		}
 
-        $drivers = [];
+		$drivers = [];
 
-        $dir = new RecursiveDirectoryIterator($path);
-        $iterator = new RecursiveIteratorIterator($dir);
-        $regex = new RegexIterator($iterator, '/^.+ValetDriver\.php$/i', RecursiveRegexIterator::GET_MATCH);
+		$dir = new RecursiveDirectoryIterator($path);
+		$iterator = new RecursiveIteratorIterator($dir);
+		$regex = new RegexIterator($iterator, '/^.+ValetDriver\.php$/i', RecursiveRegexIterator::GET_MATCH);
 
-        foreach ($regex as $file) {
-            require_once $file[0];
+		foreach ($regex as $file) {
+			require_once $file[0];
 
-            $drivers[] = basename($file[0], '.php');
-        }
+			$drivers[] = basename($file[0], '.php');
+		}
 
-        return $drivers;
-    }
+		return $drivers;
+	}
 
-    /**
-     * Mutate the incoming URI.
-     *
-     * @param  string  $uri
-     * @return string
-     */
-    public function mutateUri($uri)
-    {
-        return $uri;
-    }
+	/**
+	 * Mutate the incoming URI.
+	 *
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function mutateUri($uri)
+	{
+		return $uri;
+	}
 
-    /**
-     * Serve the static file at the given path.
-     *
-     * @param  string  $staticFilePath
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return void
-     */
-    public function serveStaticFile($staticFilePath, $sitePath, $siteName, $uri)
-    {
-        /**
-         * Back story...
-         *
-         * PHP docs *claim* you can set default_mimetype = "" to disable the default
-         * Content-Type header. This works in PHP 7+, but in PHP 5.* it sends an
-         * *empty* Content-Type header, which is significantly different than
-         * sending *no* Content-Type header.
-         *
-         * However, if you explicitly set a Content-Type header, then explicitly
-         * remove that Content-Type header, PHP seems to not re-add the default.
-         *
-         * I have a hard time believing this is by design and not coincidence.
-         *
-         * Burn. it. all.
-         */
-        header('Content-Type: text/html');
-        header_remove('Content-Type');
+	/**
+	 * Serve the static file at the given path.
+	 *
+	 * @param  string  $staticFilePath
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return void
+	 */
+	public function serveStaticFile($staticFilePath, $sitePath, $siteName, $uri)
+	{
+		/**
+		 * Back story...
+		 *
+		 * PHP docs *claim* you can set default_mimetype = "" to disable the default
+		 * Content-Type header. This works in PHP 7+, but in PHP 5.* it sends an
+		 * *empty* Content-Type header, which is significantly different than
+		 * sending *no* Content-Type header.
+		 *
+		 * However, if you explicitly set a Content-Type header, then explicitly
+		 * remove that Content-Type header, PHP seems to not re-add the default.
+		 *
+		 * I have a hard time believing this is by design and not coincidence.
+		 *
+		 * Burn. it. all.
+		 */
+		header('Content-Type: text/html');
+		header_remove('Content-Type');
 
-        header('X-Accel-Redirect: /'.VALET_STATIC_PREFIX.'/'.$staticFilePath);
-    }
+		header('X-Accel-Redirect: /'.VALET_STATIC_PREFIX.'/'.$staticFilePath);
+	}
 
-    /**
-     * Determine if the path is a file and not a directory.
-     *
-     * @param  string  $path
-     * @return bool
-     */
-    protected function isActualFile($path)
-    {
-        return ! is_dir($path) && file_exists($path);
-    }
+	/**
+	 * Determine if the path is a file and not a directory.
+	 *
+	 * @param  string  $path
+	 * @return bool
+	 */
+	protected function isActualFile($path)
+	{
+		return ! is_dir($path) && file_exists($path);
+	}
 
-    /**
-     * Load server environment variables if available.
-     * Processes any '*' entries first, and then adds site-specific entries.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @return void
-     */
-    public function loadServerEnvironmentVariables($sitePath, $siteName)
-    {
-        $varFilePath = $sitePath.'/.valet-env.php';
-        if (! file_exists($varFilePath)) {
-            return;
-        }
+	/**
+	 * Load server environment variables if available.
+	 * Processes any '*' entries first, and then adds site-specific entries.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @return void
+	 */
+	public function loadServerEnvironmentVariables($sitePath, $siteName)
+	{
+		$varFilePath = $sitePath.'/.valet-env.php';
+		if (! file_exists($varFilePath)) {
+			return;
+		}
 
-        $variables = include $varFilePath;
+		$variables = include $varFilePath;
 
-        $variablesToSet = isset($variables['*']) ? $variables['*'] : [];
+		$variablesToSet = isset($variables['*']) ? $variables['*'] : [];
 
-        if (isset($variables[$siteName])) {
-            $variablesToSet = array_merge($variablesToSet, $variables[$siteName]);
-        }
+		if (isset($variables[$siteName])) {
+			$variablesToSet = array_merge($variablesToSet, $variables[$siteName]);
+		}
 
-        foreach ($variablesToSet as $key => $value) {
-            if (! is_string($key)) {
-                continue;
-            }
-            $_SERVER[$key] = $value;
-            $_ENV[$key] = $value;
-            putenv($key.'='.$value);
-        }
-    }
+		foreach ($variablesToSet as $key => $value) {
+			if (! is_string($key)) {
+				continue;
+			}
+			$_SERVER[$key] = $value;
+			$_ENV[$key] = $value;
+			putenv($key.'='.$value);
+		}
+	}
 }

--- a/cli/drivers/WordPressValetDriver.php
+++ b/cli/drivers/WordPressValetDriver.php
@@ -2,51 +2,51 @@
 
 class WordPressValetDriver extends BasicValetDriver
 {
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        return file_exists($sitePath.'/wp-config.php') || file_exists($sitePath.'/wp-config-sample.php');
-    }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		return file_exists($sitePath.'/wp-config.php') || file_exists($sitePath.'/wp-config-sample.php');
+	}
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        $_SERVER['PHP_SELF'] = $uri;
-        $_SERVER['SERVER_ADDR'] = '127.0.0.1';
-        $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		$_SERVER['PHP_SELF'] = $uri;
+		$_SERVER['SERVER_ADDR'] = '127.0.0.1';
+		$_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
 
-        return parent::frontControllerPath(
-            $sitePath, $siteName, $this->forceTrailingSlash($uri)
-        );
-    }
+		return parent::frontControllerPath(
+			$sitePath, $siteName, $this->forceTrailingSlash($uri)
+		);
+	}
 
-    /**
-     * Redirect to uri with trailing slash.
-     *
-     * @param  string  $uri
-     * @return string
-     */
-    private function forceTrailingSlash($uri)
-    {
-        if (substr($uri, -1 * strlen('/wp-admin')) == '/wp-admin') {
-            header('Location: '.$uri.'/');
-            exit;
-        }
+	/**
+	 * Redirect to uri with trailing slash.
+	 *
+	 * @param  string  $uri
+	 * @return string
+	 */
+	private function forceTrailingSlash($uri)
+	{
+		if (substr($uri, -1 * strlen('/wp-admin')) == '/wp-admin') {
+			header('Location: '.$uri.'/');
+			exit;
+		}
 
-        return $uri;
-    }
+		return $uri;
+	}
 }

--- a/cli/includes/compatibility.php
+++ b/cli/includes/compatibility.php
@@ -6,13 +6,13 @@
 $inTestingEnvironment = strpos($_SERVER['SCRIPT_NAME'], 'phpunit') !== false;
 
 if (PHP_OS !== 'WINNT' && ! $inTestingEnvironment) {
-    echo 'Valet for Windows only supports the Windows operating system.'.PHP_EOL;
+	echo 'Valet for Windows only supports the Windows operating system.'.PHP_EOL;
 
-    exit(1);
+	exit(1);
 }
 
 if (version_compare(PHP_VERSION, '7.3.0', '<')) {
-    echo 'Valet requires PHP 7.3 or later.';
+	echo 'Valet requires PHP 7.3 or later.';
 
-    exit(1);
+	exit(1);
 }

--- a/cli/includes/facades.php
+++ b/cli/includes/facades.php
@@ -4,29 +4,29 @@ use Illuminate\Container\Container;
 
 class Facade
 {
-    /**
-     * The key for the binding in the container.
-     *
-     * @return string
-     */
-    public static function containerKey()
-    {
-        return 'Valet\\'.basename(str_replace('\\', '/', get_called_class()));
-    }
+	/**
+	 * The key for the binding in the container.
+	 *
+	 * @return string
+	 */
+	public static function containerKey()
+	{
+		return 'Valet\\'.basename(str_replace('\\', '/', get_called_class()));
+	}
 
-    /**
-     * Call a non-static method on the facade.
-     *
-     * @param  string  $method
-     * @param  array  $parameters
-     * @return mixed
-     */
-    public static function __callStatic($method, $parameters)
-    {
-        $resolvedInstance = Container::getInstance()->make(static::containerKey());
+	/**
+	 * Call a non-static method on the facade.
+	 *
+	 * @param  string  $method
+	 * @param  array  $parameters
+	 * @return mixed
+	 */
+	public static function __callStatic($method, $parameters)
+	{
+		$resolvedInstance = Container::getInstance()->make(static::containerKey());
 
-        return call_user_func_array([$resolvedInstance, $method], $parameters);
-    }
+		return call_user_func_array([$resolvedInstance, $method], $parameters);
+	}
 }
 
 class Nginx extends Facade

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -8,8 +8,8 @@ use RuntimeException;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
-if (! isset($_SERVER['HOME'])) {
-    $_SERVER['HOME'] = $_SERVER['USERPROFILE'];
+if (!isset($_SERVER['HOME'])) {
+	$_SERVER['HOME'] = $_SERVER['USERPROFILE'];
 }
 
 $_SERVER['HOME'] = str_replace('\\', '/', $_SERVER['HOME']);
@@ -17,11 +17,11 @@ $_SERVER['HOME'] = str_replace('\\', '/', $_SERVER['HOME']);
 /*
  * Define the ~/.config/valet path as a constant.
  */
-define('VALET_HOME_PATH', $_SERVER['HOME'].'/.config/valet');
-define('VALET_SERVER_PATH', str_replace('\\', '/', realpath(__DIR__.'/../../server.php')));
+define('VALET_HOME_PATH', $_SERVER['HOME'] . '/.config/valet');
+define('VALET_SERVER_PATH', str_replace('\\', '/', realpath(__DIR__ . '/../../server.php')));
 define('VALET_STATIC_PREFIX', '41c270e4-5535-4daa-b23e-c269744c2f45');
 
-define('VALET_LEGACY_HOME_PATH', $_SERVER['HOME'].'/.valet');
+define('VALET_LEGACY_HOME_PATH', $_SERVER['HOME'] . '/.valet');
 
 /**
  * Output the given text to the console.
@@ -31,7 +31,7 @@ define('VALET_LEGACY_HOME_PATH', $_SERVER['HOME'].'/.valet');
  */
 function info($output)
 {
-    output('<info>'.$output.'</info>');
+	output('<info>' . $output . '</info>');
 }
 
 /**
@@ -42,11 +42,11 @@ function info($output)
  */
 function warning($output)
 {
-    if (isset($_ENV['APP_ENV']) && $_ENV['APP_ENV'] === 'testing') {
-        throw new RuntimeException($output);
-    }
+	if (isset($_ENV['APP_ENV']) && $_ENV['APP_ENV'] === 'testing') {
+		throw new RuntimeException($output);
+	}
 
-    output('<fg=red>'.$output.'</>');
+	output('<fg=red>' . $output . '</>');
 }
 
 /**
@@ -57,11 +57,11 @@ function warning($output)
  */
 function error(string $output)
 {
-    if (isset($_ENV['APP_ENV']) && $_ENV['APP_ENV'] === 'testing') {
-        throw new RuntimeException($output);
-    }
+	if (isset($_ENV['APP_ENV']) && $_ENV['APP_ENV'] === 'testing') {
+		throw new RuntimeException($output);
+	}
 
-    (new ConsoleOutput)->getErrorOutput()->writeln("<error>$output</error>");
+	(new ConsoleOutput)->getErrorOutput()->writeln("<error>$output</error>");
 }
 
 /**
@@ -73,11 +73,11 @@ function error(string $output)
  */
 function table(array $headers = [], array $rows = [])
 {
-    $table = new Table(new ConsoleOutput());
+	$table = new Table(new ConsoleOutput());
 
-    $table->setHeaders($headers)->setRows($rows);
+	$table->setVertical()->setHeaders($headers)->setRows($rows);
 
-    $table->render();
+	$table->render();
 }
 
 /**
@@ -88,24 +88,24 @@ function table(array $headers = [], array $rows = [])
  */
 function output($output)
 {
-    if (isset($_ENV['APP_ENV']) && $_ENV['APP_ENV'] === 'testing') {
-        return;
-    }
+	if (isset($_ENV['APP_ENV']) && $_ENV['APP_ENV'] === 'testing') {
+		return;
+	}
 
-    (new ConsoleOutput())->writeln($output);
+	(new ConsoleOutput())->writeln($output);
 }
 
-if (! function_exists('resolve')) {
-    /**
-     * Resolve the given class from the container.
-     *
-     * @param  string  $class
-     * @return mixed
-     */
-    function resolve($class)
-    {
-        return Container::getInstance()->make($class);
-    }
+if (!function_exists('resolve')) {
+	/**
+	 * Resolve the given class from the container.
+	 *
+	 * @param  string  $class
+	 * @return mixed
+	 */
+	function resolve($class)
+	{
+		return Container::getInstance()->make($class);
+	}
 }
 
 /**
@@ -117,37 +117,37 @@ if (! function_exists('resolve')) {
  */
 function swap($class, $instance)
 {
-    Container::getInstance()->instance($class, $instance);
+	Container::getInstance()->instance($class, $instance);
 }
 
-if (! function_exists('retry')) {
-    /**
-     * Retry the given function N times.
-     *
-     * @param  int  $retries
-     * @param  callable  $retries
-     * @param  int  $sleep
-     * @return mixed
-     */
-    function retry($retries, $fn, $sleep = 0)
-    {
-        beginning:
-        try {
-            return $fn();
-        } catch (Exception $e) {
-            if (! $retries) {
-                throw $e;
-            }
+if (!function_exists('retry')) {
+	/**
+	 * Retry the given function N times.
+	 *
+	 * @param  int  $retries
+	 * @param  callable  $retries
+	 * @param  int  $sleep
+	 * @return mixed
+	 */
+	function retry($retries, $fn, $sleep = 0)
+	{
+		beginning:
+		try {
+			return $fn();
+		} catch (Exception $e) {
+			if (!$retries) {
+				throw $e;
+			}
 
-            $retries--;
+			$retries--;
 
-            if ($sleep > 0) {
-                usleep($sleep * 1000);
-            }
+			if ($sleep > 0) {
+				usleep($sleep * 1000);
+			}
 
-            goto beginning;
-        }
-    }
+			goto beginning;
+		}
+	}
 }
 
 /**
@@ -157,65 +157,65 @@ if (! function_exists('retry')) {
  */
 function should_be_sudo()
 {
-    if (! isset($_SERVER['SUDO_USER'])) {
-        throw new Exception('This command must be run with sudo.');
-    }
+	if (!isset($_SERVER['SUDO_USER'])) {
+		throw new Exception('This command must be run with sudo.');
+	}
 }
 
-if (! function_exists('tap')) {
-    /**
-     * Tap the given value.
-     *
-     * @param  mixed  $value
-     * @param  callable  $callback
-     * @return mixed
-     */
-    function tap($value, callable $callback)
-    {
-        $callback($value);
+if (!function_exists('tap')) {
+	/**
+	 * Tap the given value.
+	 *
+	 * @param  mixed  $value
+	 * @param  callable  $callback
+	 * @return mixed
+	 */
+	function tap($value, callable $callback)
+	{
+		$callback($value);
 
-        return $value;
-    }
+		return $value;
+	}
 }
 
-if (! function_exists('ends_with')) {
-    /**
-     * Determine if a given string ends with a given substring.
-     *
-     * @param  string  $haystack
-     * @param  string|array  $needles
-     * @return bool
-     */
-    function ends_with($haystack, $needles)
-    {
-        foreach ((array) $needles as $needle) {
-            if (substr($haystack, -strlen($needle)) === (string) $needle) {
-                return true;
-            }
-        }
+if (!function_exists('ends_with')) {
+	/**
+	 * Determine if a given string ends with a given substring.
+	 *
+	 * @param  string  $haystack
+	 * @param  string|array  $needles
+	 * @return bool
+	 */
+	function ends_with($haystack, $needles)
+	{
+		foreach ((array) $needles as $needle) {
+			if (substr($haystack, -strlen($needle)) === (string) $needle) {
+				return true;
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 }
 
-if (! function_exists('starts_with')) {
-    /**
-     * Determine if a given string starts with a given substring.
-     *
-     * @param  string  $haystack
-     * @param  string|string[]  $needles
-     * @return bool
-     */
-    function starts_with($haystack, $needles)
-    {
-        foreach ((array) $needles as $needle) {
-            if ((string) $needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0) {
-                return true;
-            }
-        }
+if (!function_exists('starts_with')) {
+	/**
+	 * Determine if a given string starts with a given substring.
+	 *
+	 * @param  string  $haystack
+	 * @param  string|string[]  $needles
+	 * @return bool
+	 */
+	function starts_with($haystack, $needles)
+	{
+		foreach ((array) $needles as $needle) {
+			if ((string) $needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0) {
+				return true;
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 }
 
 /**
@@ -225,13 +225,13 @@ if (! function_exists('starts_with')) {
  */
 function user()
 {
-    if (! isset($_SERVER['SUDO_USER'])) {
-        if (! isset($_SERVER['USER'])) {
-            return $_SERVER['USERNAME'];
-        }
+	if (!isset($_SERVER['SUDO_USER'])) {
+		if (!isset($_SERVER['USER'])) {
+			return $_SERVER['USERNAME'];
+		}
 
-        return $_SERVER['USER'];
-    }
+		return $_SERVER['USER'];
+	}
 
-    return $_SERVER['SUDO_USER'];
+	return $_SERVER['SUDO_USER'];
 }

--- a/cli/stubs/SampleValetDriver.php
+++ b/cli/stubs/SampleValetDriver.php
@@ -2,50 +2,50 @@
 
 class SampleValetDriver extends ValetDriver
 {
-    /**
-     * Determine if the driver serves the request.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return bool
-     */
-    public function serves($sitePath, $siteName, $uri)
-    {
-        // if (file_exists($sitePath.'/file-that-identifies-my-framework')) {
-        //     return true;
-        // }
+	/**
+	 * Determine if the driver serves the request.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return bool
+	 */
+	public function serves($sitePath, $siteName, $uri)
+	{
+		// if (file_exists($sitePath.'/file-that-identifies-my-framework')) {
+		//     return true;
+		// }
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Determine if the incoming request is for a static file.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string|false
-     */
-    public function isStaticFile($sitePath, $siteName, $uri)
-    {
-        if (file_exists($staticFilePath = $sitePath.'/public/'.$uri)) {
-            return $staticFilePath;
-        }
+	/**
+	 * Determine if the incoming request is for a static file.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string|false
+	 */
+	public function isStaticFile($sitePath, $siteName, $uri)
+	{
+		if (file_exists($staticFilePath = $sitePath.'/public/'.$uri)) {
+			return $staticFilePath;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Get the fully resolved path to the application's front controller.
-     *
-     * @param  string  $sitePath
-     * @param  string  $siteName
-     * @param  string  $uri
-     * @return string
-     */
-    public function frontControllerPath($sitePath, $siteName, $uri)
-    {
-        return $sitePath.'/public/index.php';
-    }
+	/**
+	 * Get the fully resolved path to the application's front controller.
+	 *
+	 * @param  string  $sitePath
+	 * @param  string  $siteName
+	 * @param  string  $uri
+	 * @return string
+	 */
+	public function frontControllerPath($sitePath, $siteName, $uri)
+	{
+		return $sitePath.'/public/index.php';
+	}
 }

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -252,7 +252,7 @@ if (is_dir(VALET_HOME_PATH)) {
     $app->command('links', function () {
         $links = Site::links();
 
-        table(['Site', 'SSL', 'URL', 'Path'], $links->all());
+        table(['Site', 'SSL', 'Php', 'URL', 'Path'], $links->all());
     })->descriptions('Display all of the registered Valet links');
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -3,10 +3,10 @@
 /**
  * Load correct autoloader depending on install location.
  */
-if (file_exists(__DIR__.'/../vendor/autoload.php')) {
-    require_once __DIR__.'/../vendor/autoload.php';
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+	require_once __DIR__ . '/../vendor/autoload.php';
 } else {
-    require_once __DIR__.'/../../../autoload.php';
+	require_once __DIR__ . '/../../../autoload.php';
 }
 
 use Illuminate\Container\Container;
@@ -20,8 +20,8 @@ use function Valet\warning;
 /**
  * Relocate config dir to ~/.config/valet/ if found in old location.
  */
-if (is_dir(VALET_LEGACY_HOME_PATH) && ! is_dir(VALET_HOME_PATH)) {
-    Configuration::createConfigurationDirectory();
+if (is_dir(VALET_LEGACY_HOME_PATH) && !is_dir(VALET_HOME_PATH)) {
+	Configuration::createConfigurationDirectory();
 }
 
 /**
@@ -37,93 +37,93 @@ $app = new Application('Laravel Valet', $version);
  * Prune missing directories and symbolic links on every command.
  */
 if (is_dir(VALET_HOME_PATH)) {
-    Configuration::prune();
+	Configuration::prune();
 
-    Site::pruneLinks();
+	Site::pruneLinks();
 }
 
 /**
  * Add PHP.
  */
 $app->command('php:add [path]', function ($path) {
-    info("Adding {$path}...");
+	info("Adding {$path}...");
 
-    if ($php = Configuration::addPhp($path)) {
-        \PhpCgi::install($php['version']);
+	if ($php = Configuration::addPhp($path)) {
+		\PhpCgi::install($php['version']);
 
-        \PhpCgiXdebug::install($php['version']);
+		\PhpCgiXdebug::install($php['version']);
 
-        info("PHP {$php['version']} from {$path} has been added. You can make it default by running `valet use` command");
-    }
+		info("PHP {$php['version']} from {$path} has been added. You can make it default by running `valet use` command");
+	}
 })->descriptions('Add PHP by specifying a path');
 
 /**
  * Remove PHP.
  */
 $app->command('php:remove [path]', function ($path) {
-    info("Removing {$path}...");
+	info("Removing {$path}...");
 
-    $config = Configuration::read();
-    $defaultPhp = $config['default_php'];
-    $php = Configuration::getPhp($path);
+	$config = Configuration::read();
+	$defaultPhp = $config['default_php'];
+	$php = Configuration::getPhp($path);
 
-    if ($php['version'] === $defaultPhp) {
-        warning("Default PHP {$php['version']} cannot be removed. Change default PHP version by running [valet use VERSION]");
+	if ($php['version'] === $defaultPhp) {
+		warning("Default PHP {$php['version']} cannot be removed. Change default PHP version by running [valet use VERSION]");
 
-        return;
-    }
+		return;
+	}
 
-    if ($php) {
-        \PhpCgi::uninstall($php['version']);
+	if ($php) {
+		\PhpCgi::uninstall($php['version']);
 
-        \PhpCgiXdebug::uninstall($php['version']);
-    }
+		\PhpCgiXdebug::uninstall($php['version']);
+	}
 
-    if (Configuration::removePhp($path)) {
-        info("PHP {$php['version']} from {$path} has been removed.");
-    }
+	if (Configuration::removePhp($path)) {
+		info("PHP {$php['version']} from {$path} has been removed.");
+	}
 })->descriptions('Remove PHP by specifying a path');
 
 /**
  * Install PHP services.
  */
 $app->command('php:install', function () {
-    info('Reinstalling services...');
+	info('Reinstalling services...');
 
-    PhpCgi::uninstall();
+	PhpCgi::uninstall();
 
-    PhpCgi::install();
+	PhpCgi::install();
 })->descriptions('Reinstall all PHP services from [valet php:list]');
 
 /**
  * Uninstall PHP services.
  */
 $app->command('php:uninstall', function () {
-    info('Uninstalling PHP services...');
+	info('Uninstalling PHP services...');
 
-    PhpCgi::uninstall();
+	PhpCgi::uninstall();
 
-    info('PHP services uninstalled. Run php:install to install again');
+	info('PHP services uninstalled. Run php:install to install again');
 })->descriptions('Uninstall all PHP services from [valet php:list]');
 
 /**
  * List all PHP services.
  */
 $app->command('php:list', function () {
-    info('Listing PHP services...');
+	info('Listing PHP services...');
 
-    $config = Configuration::read();
-    $defaultPhpVersion = $config['default_php'];
+	$config = Configuration::read();
+	$defaultPhpVersion = $config['default_php'];
 
-    $php = $config['php'] ?? [];
+	$php = $config['php'] ?? [];
 
-    $php = collect($php)->map(function ($item) use ($defaultPhpVersion) {
-        $item['default'] = $defaultPhpVersion === $item['version'] ? 'X' : '';
+	$php = collect($php)->map(function ($item) use ($defaultPhpVersion) {
+		$item['default'] = $defaultPhpVersion === $item['version'] ? 'X' : '';
 
-        return $item;
-    })->toArray();
+		return $item;
+	})->toArray();
 
-    table(['Version', 'Path', 'Port', 'xDebug Port', 'Default'], $php);
+	table(['Version', 'Path', 'Port', 'xDebug Port', 'Default'], $php);
 })->descriptions('List all PHP services');
 
 /**
@@ -141,91 +141,91 @@ $app->command('php:which', function () {
  * Install PHP xDebug services.
  */
 $app->command('xdebug:install', function () {
-    info('Reinstalling xDebug services...');
+	info('Reinstalling xDebug services...');
 
-    PhpCgiXdebug::uninstall();
+	PhpCgiXdebug::uninstall();
 
-    PhpCgiXdebug::install();
+	PhpCgiXdebug::install();
 })->descriptions('Reinstall all PHP xDebug services from [valet php:list]');
 
 /**
  * uninstall PHP xDebug services.
  */
 $app->command('xdebug:uninstall', function () {
-    info('Uninstalling xDebug services...');
+	info('Uninstalling xDebug services...');
 
-    PhpCgiXdebug::uninstall();
+	PhpCgiXdebug::uninstall();
 
-    info('xDebug services uninstalled. Run xdebug:install to install again');
+	info('xDebug services uninstalled. Run xdebug:install to install again');
 })->descriptions('Uninstall all PHP xDebug services from [valet php:list]');
 
 /**
  * Install Valet and any required services.
  */
 $app->command('install', function () {
-    Configuration::install();
-    Nginx::install();
-    PhpCgi::install();
-    PhpCgiXdebug::install();
-    Acrylic::install(Configuration::read()['tld']);
+	Configuration::install();
+	Nginx::install();
+	PhpCgi::install();
+	PhpCgiXdebug::install();
+	Acrylic::install(Configuration::read()['tld']);
 
-    output(PHP_EOL.'<info>Valet installed successfully!</info>');
+	output(PHP_EOL . '<info>Valet installed successfully!</info>');
 })->descriptions('Install the Valet services');
 
 /**
  * Most commands are available only if valet is installed.
  */
 if (is_dir(VALET_HOME_PATH)) {
-    /**
-     * Upgrade helper: ensure the tld config exists.
-     */
-    if (empty(Configuration::read()['tld'])) {
-        Configuration::writeBaseConfiguration();
-    }
+	/**
+	 * Upgrade helper: ensure the tld config exists.
+	 */
+	if (empty(Configuration::read()['tld'])) {
+		Configuration::writeBaseConfiguration();
+	}
 
-    /**
-     * Get or set the TLD currently being used by Valet.
-     */
-    $app->command('tld [tld]', function ($tld = null) {
-        if ($tld === null) {
-            return info(Configuration::read()['tld']);
-        }
+	/**
+	 * Get or set the TLD currently being used by Valet.
+	 */
+	$app->command('tld [tld]', function ($tld = null) {
+		if ($tld === null) {
+			return info(Configuration::read()['tld']);
+		}
 
-        $oldTld = Configuration::read()['tld'];
+		$oldTld = Configuration::read()['tld'];
 
-        Acrylic::updateTld($tld = trim($tld, '.'));
+		Acrylic::updateTld($tld = trim($tld, '.'));
 
-        Configuration::updateKey('tld', $tld);
+		Configuration::updateKey('tld', $tld);
 
-        Site::resecureForNewTld($oldTld, $tld);
-        PhpCgi::restart();
-        PhpCgiXdebug::restart();
-        Nginx::restart();
+		Site::resecureForNewTld($oldTld, $tld);
+		PhpCgi::restart();
+		PhpCgiXdebug::restart();
+		Nginx::restart();
 
-        info('Your Valet TLD has been updated to ['.$tld.'].');
-    }, ['domain'])->descriptions('Get or set the TLD used for Valet sites.');
+		info('Your Valet TLD has been updated to [' . $tld . '].');
+	}, ['domain'])->descriptions('Get or set the TLD used for Valet sites.');
 
-    /**
-     * Add the current working directory to the paths configuration.
-     */
-    $app->command('park [path]', function ($path = null) {
-        Configuration::addPath($path ?: getcwd());
+	/**
+	 * Add the current working directory to the paths configuration.
+	 */
+	$app->command('park [path]', function ($path = null) {
+		Configuration::addPath($path ?: getcwd());
 
-//        Site::publishParkedNginxConf($path ?: getcwd());
+		//        Site::publishParkedNginxConf($path ?: getcwd());
 
-        info(($path === null ? 'This' : "The [{$path}]")." directory has been added to Valet's paths.");
-    })->descriptions('Register the current working (or specified) directory with Valet');
+		info(($path === null ? 'This' : "The [{$path}]") . " directory has been added to Valet's paths.");
+	})->descriptions('Register the current working (or specified) directory with Valet');
 
-    /**
-     * Get all the current sites within paths parked with 'park {path}'.
-     */
-    $app->command('parked', function () {
-        $parked = Site::parked();
+	/**
+	 * Get all the current sites within paths parked with 'park {path}'.
+	 */
+	$app->command('parked', function () {
+		$parked = Site::parked();
 
-        table(['Site', 'SSL', 'PHP', 'URL', 'Path'], $parked->all());
-    })->descriptions('Display all the current sites within parked paths');
+		table(['Site', 'Alias', 'SSL', 'PHP', 'URL', 'Alias URL', 'Path'], $parked->all());
+	})->descriptions('Display all the current sites within parked paths');
 
-//    /**
+	//    /**
 //     * Get all the current sites within paths parked with 'park {path}'.
 //     */
 //    $app->command('nginx:publish', function ($type) {
@@ -235,502 +235,512 @@ if (is_dir(VALET_HOME_PATH)) {
 //
 //    })->descriptions('Publish ');
 
-    /**
-     * Remove the current working directory from the paths configuration.
-     */
-    $app->command('forget [path]', function ($path = null) {
-        Configuration::removePath($path ?: getcwd());
-
-        info(($path === null ? 'This' : "The [{$path}]")." directory has been removed from Valet's paths.");
-    }, ['unpark'])->descriptions('Remove the current working (or specified) directory from Valet\'s list of paths');
-
-    /**
-     * Register a symbolic link with Valet.
-     */
-    $app->command('link [name] [--secure]', function ($name, $secure) {
-        $linkPath = Site::link(getcwd(), $name = $name ?: basename(getcwd()));
-
-        info('A ['.$name.'] symbolic link has been created in ['.$linkPath.'].');
-
-        if ($secure) {
-            $this->runCommand('secure '.$name);
-        }
-    })->descriptions('Link the current working directory to Valet');
-
-    /**
-     * Display all of the registered symbolic links.
-     */
-    $app->command('links', function () {
-        $links = Site::links();
-
-        table(['Site', 'SSL', 'PHP', 'URL', 'Path'], $links->all());
-    })->descriptions('Display all of the registered Valet links');
-
-    /**
-     * Unlink a link from the Valet links directory.
-     */
-    $app->command('unlink [name]', function ($name) {
-        info('The ['.Site::unlink($name).'] symbolic link has been removed.');
-    })->descriptions('Remove the specified Valet link');
-
-    /**
-     * Secure the given domain with a trusted TLS certificate.
-     */
-    $app->command('secure [domain]', function ($domain = null) {
-        $url = ($domain ?: Site::host(getcwd())).'.'.Configuration::read()['tld'];
-
-        Site::secure($url);
-
-        Nginx::restart();
-
-        info('The ['.$url.'] site has been secured with a fresh TLS certificate.');
-    })->descriptions('Secure the given domain with a trusted TLS certificate');
-
-    /**
-     * Stop serving the given domain over HTTPS and remove the trusted TLS certificate.
-     */
-    $app->command('unsecure [domain] [--all]', function ($domain = null, $all = null) {
-        if ($all) {
-            Site::unsecureAll();
-            Nginx::restart();
-
-            return;
-        }
-
-        $url = ($domain ?: Site::host(getcwd())).'.'.Configuration::read()['tld'];
-
-        Site::unsecure($url);
-        Nginx::restart();
-
-        info('The ['.$url.'] site will now serve traffic over HTTP.');
-    })->descriptions('Stop serving the given domain over HTTPS and remove the trusted TLS certificate');
-
-    /**
-     * Create an Nginx proxy config for the specified domain.
-     */
-    $app->command('proxy domain host', function ($domain, $host) {
-        Site::proxyCreate($domain, $host);
-        Nginx::restart();
-    })->descriptions('Create an Nginx proxy site for the specified host. Useful for docker, mailhog etc.');
-
-    /**
-     * Delete an Nginx proxy config.
-     */
-    $app->command('unproxy domain', function ($domain) {
-        Site::proxyDelete($domain);
-        Nginx::restart();
-    })->descriptions('Delete an Nginx proxy config.');
-
-    /**
-     * Display all of the sites that are proxies.
-     */
-    $app->command('proxies', function () {
-        $proxies = Site::proxies();
-
-        table(['Site', 'SSL', 'URL', 'Host'], $proxies->all());
-    })->descriptions('Display all of the proxy sites');
-
-    /**
-     * Determine which Valet driver the current directory is using.
-     */
-    $app->command('which', function () {
-        require __DIR__.'/drivers/require.php';
-
-        $driver = ValetDriver::assign(getcwd(), basename(getcwd()), '/');
-
-        if ($driver) {
-            info('This site is served by ['.get_class($driver).'].');
-        } else {
-            warning('Valet could not determine which driver to use for this site.');
-        }
-    })->descriptions('Determine which Valet driver serves the current working directory');
-
-    /**
-     * Display all of the registered paths.
-     */
-    $app->command('paths', function () {
-        $paths = Configuration::read()['paths'];
-
-        if (count($paths) > 0) {
-            output(json_encode($paths, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
-        } else {
-            info('No paths have been registered.');
-        }
-    })->descriptions('Get all of the paths registered with Valet');
-
-    /**
-     * Open the current or given directory in the browser.
-     */
-    $app->command('open [domain]', function ($domain = null) {
-        $url = 'http://'.($domain ?: Site::host(getcwd())).'.'.Configuration::read()['tld'];
-        CommandLine::passthru("start $url");
-    })->descriptions('Open the site for the current (or specified) directory in your browser');
-
-    /**
-     * Generate a publicly accessible URL for your project.
-     */
-    // TODO: custom domain and ngrok params
-    $app->command('share [domain] [--authtoken=] [--host-header=] [--hostname=] [--region=] [--subdomain=]',
-        function ($domain = null, $authtoken = null, $hostheader = null, $hostname = null, $region = null, $subdomain = null) {
-            $url = ($domain ?: strtolower(Site::host(getcwd()))).'.'.Configuration::read()['tld'];
-
-            Ngrok::start($url, Site::port($url), array_filter([
-                'authtoken' => $authtoken,
-                'host-header' => $hostheader,
-                'hostname' => $hostname,
-                'region' => $region,
-                'subdomain' => $subdomain,
-            ]));
-        })->defaults([
-            'host-header' => 'rewrite',
-        ])->descriptions('Generate a publicly accessible URL for your project');
-
-    /**
-     * Echo the currently tunneled URL.
-     */
-    $app->command('fetch-share-url [domain]', function ($domain = null) {
-        output(Ngrok::currentTunnelUrl($domain ?: Site::host(getcwd()).'.'.Configuration::read()['tld']));
-    })->descriptions('Get the URL to the current Ngrok tunnel');
-
-    /**
-     * Run ngrok commands.
-     */
-    $app->command('ngrok [args]*', function ($args) {
-        Ngrok::run(implode(' ', $args));
-    })->descriptions('Run ngrok commands');
-
-    /**
-     * Start the daemon services.
-     */
-    $app->command('start [service]', function ($service) {
-        switch ($service) {
-            case '':
-                Acrylic::restart();
-                PhpCgi::restart();
-                PhpCgiXdebug::restart();
-                Nginx::restart();
-
-                return info('Valet services have been started.');
-            case 'acrylic':
-                Acrylic::restart();
-
-                return info('Acrylic DNS has been started.');
-            case 'nginx':
-                Nginx::restart();
-
-                return info('Nginx has been started.');
-            case 'php':
-                PhpCgi::restart();
-
-                return info('PHP has been started.');
-            case 'php-xdebug':
-                PhpCgiXdebug::restart();
-
-                return info('PHP Xdebug has been started.');
-        }
-
-        return warning(sprintf('Invalid valet service name [%s]', $service));
-    })->descriptions('Start the Valet services');
-
-    /**
-     * Restart the daemon services.
-     */
-    $app->command('restart [service]', function ($service) {
-        switch ($service) {
-            case '':
-                Acrylic::restart();
-                PhpCgi::restart();
-                PhpCgiXdebug::restart();
-                Nginx::restart();
-
-                return info('Valet services have been restarted.');
-            case 'acrylic':
-                Acrylic::restart();
-
-                return info('Acrylic DNS has been restarted.');
-            case 'nginx':
-                Nginx::restart();
-
-                return info('Nginx has been restarted.');
-            case 'php':
-                PhpCgi::restart();
-
-                return info('PHP has been restarted.');
-            case 'php-xdebug':
-                PhpCgiXdebug::restart();
-
-                return info('PHP Xdebug has been restarted.');
-        }
-
-        return warning(sprintf('Invalid valet service name [%s]', $service));
-    })->descriptions('Restart the Valet services');
-
-    /**
-     * Stop the daemon services.
-     */
-    $app->command('stop [service]', function ($service) {
-        switch ($service) {
-            case '':
-                Acrylic::stop();
-                Nginx::stop();
-                PhpCgi::stop();
-                PhpCgiXdebug::stop();
-
-                return info('Valet services have been stopped.');
-            case 'acrylic':
-                Acrylic::stop();
-
-                return info('Acrylic DNS has been stopped.');
-            case 'nginx':
-                Nginx::stop();
-
-                return info('Nginx has been stopped.');
-            case 'php':
-                PhpCgi::stop();
-
-                return info('PHP has been stopped.');
-            case 'php-xdebug':
-                PhpCgiXdebug::stop();
-
-                return info('PHP Xdebug has been stopped.');
-        }
-
-        return warning(sprintf('Invalid valet service name [%s]', $service));
-    })->descriptions('Stop the Valet services');
-
-    /**
-     * Uninstall Valet entirely. Requires --force to actually remove; otherwise manual instructions are displayed.
-     */
-    $app->command('uninstall [--force] [--purge-config]', function ($input, $output, $force, $purgeConfig) {
-        warning('YOU ARE ABOUT TO UNINSTALL Nginx, PHP-CGI, Acrylic DNS and all Valet configs and logs.');
-
-        $helper = $this->getHelperSet()->get('question');
-        $question = new ConfirmationQuestion("Are you sure you want to proceed? yes/no\n", false);
-        if (! $force && ! $helper->ask($input, $output, $question)) {
-            return warning('Uninstall aborted.');
-        }
-
-        info('Stopping services...');
-
-        Acrylic::stop();
-        Nginx::stop();
-        PhpCgi::stop();
-        PhpCgiXdebug::stop();
-
-        if ($purgeConfig) {
-            info('Removing certificates for all secured sites...');
-            Site::unsecureAll();
-        } else {
-            Site::untrustCertificates();
-        }
-
-        info('Removing Nginx...');
-        Nginx::uninstall();
-
-        info('Removing Acrylic DNS...');
-        Acrylic::uninstall();
-
-        info('Removing PHP-CGI...');
-        PhpCgi::uninstall();
-
-        info('Removing PHP-CGI Xdebug...');
-        PhpCgiXdebug::uninstall();
-
-        if ($purgeConfig) {
-            info('Removing Valet configs...');
-            Configuration::uninstall();
-        }
-
-        info("\nValet has been removed from your system.");
-
-        output(
-            "\n<fg=yellow>NOTE:</>".
-            "\nRemove composer dependency with: <info>composer global remove cretueusebiu/valet-windows</info>".
-            ($purgeConfig ? '' : "\nDelete the config files from: <info>~/.config/valet</info>").
-            "\nDelete PHP from: <info>C:/php</info>"
-        );
-    })->descriptions('Uninstall the Valet services', ['--force' => 'Do a forceful uninstall of Valet']);
-
-    /**
-     * Determine if this is the latest release of Valet.
-     */
-    $app->command('on-latest-version', function () use ($version) {
-        if (Valet::onLatestVersion($version)) {
-            output('Yes');
-        } else {
-            output(sprintf('Your version of Valet (%s) is not the latest version available.', $version));
-            output('Upgrade instructions can be found in the docs: https://github.com/cretueusebiu/valet-windows#upgrading');
-        }
-    })->descriptions('Determine if this is the latest version of Valet');
-
-    /**
-     * Install the sudoers.d entries so password is no longer required.
-     */
-    $app->command('trust [--off]', function ($off) {
-        warning('This command is not required for Windows.');
-    })->descriptions('This command is not required for Windows.');
-
-    /**
-     * Allow the user to change the version of php valet uses.
-     *
-     *  @param string $phpVersion can be 'default' or PHP version eg. 8.1.12
-     */
-    $app->command('use [phpVersion] [--site=]', function ($phpVersion, $site) {
-        if (empty($phpVersion)) {
-            warning('Please enter a PHP version. Example command [valet use 7.3]');
-
-            return;
-        }
-
-        if ($site) {
-            Site::usePhp($phpVersion, $site);
-
-            return;
-        }
-
-        $php = Configuration::getPhpByVersion($phpVersion);
-
-        if (empty($php)) {
-            warning("Cannot find PHP [$phpVersion] in the list. Example command [valet use 7.3]");
-        }
-
-        info("Setting the default PHP version to [$phpVersion].");
-
-        Configuration::updateKey('default_php', $php['version']);
-
-        info('Stopping Nginx...');
-        Nginx::stop();
-
-        Nginx::installConfiguration();
-        Nginx::installServer();
-        Nginx::installNginxDirectory();
-        Nginx::installService();
-        Nginx::restart();
-
-        info(sprintf('Valet is now using %s.', $php['version']).PHP_EOL);
-        info('Note that you might need to run <comment>composer global update</comment> if your PHP version change affects the dependencies of global packages required by Composer.');
-    })->descriptions('Change the version of PHP used by valet', [
-        'phpVersion' => 'The PHP version you want to use, e.g 7.3',
-        '--site' => 'Isolate PHP version of a specific valet site. e.g: --site=site.test',
-    ]);
-
-    /**
-     * Tail log file.
-     */
-    $app->command('log [-f|--follow] [-l|--lines=] [key]', function ($follow, $lines, $key = null) {
-        $defaultLogs = [
-            'nginx' => VALET_HOME_PATH.'/Log/nginx-error.log',
-            'nginxservice.err' => VALET_HOME_PATH.'/Log/nginxservice.err.log',
-            'nginxservice.out' => VALET_HOME_PATH.'/Log/nginxservice.out.log',
-            'nginxservice.wrapper' => VALET_HOME_PATH.'/Log/nginxservice.wrapper.log',
-            'phpcgiservice.err' => VALET_HOME_PATH.'/Log/phpcgiservice.err.log',
-            'phpcgiservice.out' => VALET_HOME_PATH.'/Log/phpcgiservice.out.log',
-            'phpcgiservice.wrapper' => VALET_HOME_PATH.'/Log/phpcgiservice.wrapper.log',
-        ];
-
-        $configLogs = data_get(Configuration::read(), 'logs');
-        if (! is_array($configLogs)) {
-            $configLogs = [];
-        }
-
-        $logs = array_merge($defaultLogs, $configLogs);
-        ksort($logs);
-
-        if (! $key) {
-            info(implode(PHP_EOL, [
-                'In order to tail a log, pass the relevant log key (e.g. "nginx")',
-                'along with any optional tail parameters (e.g. "-f" for follow).',
-                null,
-                'For example: "valet log nginx -f --lines=3"',
-                null,
-                'Here are the logs you might be interested in.',
-                null,
-            ]));
-
-            table(
-                ['Key', 'File'],
-                collect($logs)->map(function ($file, $key) {
-                    return [$key, $file];
-                })->toArray()
-            );
-
-            info(implode(PHP_EOL, [
-                null,
-                'Tip: Set custom logs by adding a "logs" key/file object',
-                'to your "'.Configuration::path().'" file.',
-            ]));
-
-            exit;
-        }
-
-        if (! isset($logs[$key])) {
-            return warning('No logs found for ['.$key.'].');
-        }
-
-        $file = $logs[$key];
-        if (! file_exists($file)) {
-            return warning('Log path ['.$file.'] does not (yet) exist.');
-        }
-
-        $options = [];
-        if ($follow) {
-            $options[] = '-f';
-        }
-        if ((int) $lines) {
-            $options[] = '-n '.(int) $lines;
-        }
-
-        $command = implode(' ', array_merge(['tail'], $options, [$file]));
-
-        passthru($command);
-    })->descriptions('Tail log file');
-
-    /**
-     * List the installed Valet services.
-     */
-    $app->command('services', function () {
-        table(['Service', 'Windows Name', 'Status'], Valet::services());
-        info('Use valet start/stop/restart [service] to change status (eg: valet restart nginx).');
-    })->descriptions('List the installed Windows services.');
-
-    /**
-     * Configure or display the directory-listing setting.
-     */
-    $app->command('directory-listing [status]', function ($status = null) {
-        $key = 'directory-listing';
-        $config = Configuration::read();
-
-        if (in_array($status, ['on', 'off'])) {
-            $config[$key] = $status;
-            Configuration::write($config);
-
-            return output('Directory listing setting is now: '.$status);
-        }
-
-        $current = isset($config[$key]) ? $config[$key] : 'off';
-        output('Directory listing is '.$current);
-    })->descriptions('Determine directory-listing behavior. Default is off, which means a 404 will display.', [
-        'status' => 'on or off. (default=off) will show a 404 page; [on] will display a listing if project folder exists but requested URI not found',
-    ]);
-
-    /**
-     * Output diagnostics to aid in debugging Valet.
-     */
-    $app->command('diagnose [-p|--print] [--plain]', function ($print, $plain) {
-        info('Running diagnostics... (this may take a while)');
-
-        Diagnose::run($print, $plain);
-    })->descriptions('Output diagnostics to aid in debugging Valet.', [
-        '--print' => 'print diagnostics output while running',
-        '--plain' => 'format clipboard output as plain text',
-    ]);
+	/**
+	 * Remove the current working directory from the paths configuration.
+	 */
+	$app->command('forget [path]', function ($path = null) {
+		Configuration::removePath($path ?: getcwd());
+
+		info(($path === null ? 'This' : "The [{$path}]") . " directory has been removed from Valet's paths.");
+	}, ['unpark'])->descriptions('Remove the current working (or specified) directory from Valet\'s list of paths');
+
+	/**
+	 * Register a symbolic link with Valet.
+	 */
+	$app->command('link [name] [--secure]', function ($name, $secure) {
+		$linkPath = Site::link(getcwd(), $name = $name ?: basename(getcwd()));
+
+		info('A [' . $name . '] symbolic link has been created in [' . $linkPath . '].');
+
+		if ($secure) {
+			$this->runCommand('secure ' . $name);
+		}
+	})->descriptions('Link the current working directory to Valet');
+
+	/**
+	 * Display all of the registered symbolic links.
+	 */
+	$app->command('links', function () {
+		$links = Site::links();
+
+		// Recreate the list of links and remove the key of alias and aliasUrl,
+		// as this is unnecessary for this command.
+		$links = $links->map(function ($value, $key) {
+			unset($value['alias']);
+			unset($value['aliasUrl']);
+			return $value;
+		});
+
+		table(['Site', 'SSL', 'PHP', 'URL', 'Path'], $links->all());
+	})->descriptions('Display all of the registered Valet links');
+
+	/**
+	 * Unlink a link from the Valet links directory.
+	 */
+	$app->command('unlink [name]', function ($name) {
+		info('The [' . Site::unlink($name) . '] symbolic link has been removed.');
+	})->descriptions('Remove the specified Valet link');
+
+	/**
+	 * Secure the given domain with a trusted TLS certificate.
+	 */
+	$app->command('secure [domain]', function ($domain = null) {
+		$url = ($domain ?: Site::host(getcwd())) . '.' . Configuration::read()['tld'];
+
+		Site::secure($url);
+
+		Nginx::restart();
+
+		info('The [' . $url . '] site has been secured with a fresh TLS certificate.');
+	})->descriptions('Secure the given domain with a trusted TLS certificate');
+
+	/**
+	 * Stop serving the given domain over HTTPS and remove the trusted TLS certificate.
+	 */
+	$app->command('unsecure [domain] [--all]', function ($domain = null, $all = null) {
+		if ($all) {
+			Site::unsecureAll();
+			Nginx::restart();
+
+			return;
+		}
+
+		$url = ($domain ?: Site::host(getcwd())) . '.' . Configuration::read()['tld'];
+
+		Site::unsecure($url);
+		Nginx::restart();
+
+		info('The [' . $url . '] site will now serve traffic over HTTP.');
+	})->descriptions('Stop serving the given domain over HTTPS and remove the trusted TLS certificate');
+
+	/**
+	 * Create an Nginx proxy config for the specified domain.
+	 */
+	$app->command('proxy domain host', function ($domain, $host) {
+		Site::proxyCreate($domain, $host);
+		Nginx::restart();
+	})->descriptions('Create an Nginx proxy site for the specified host. Useful for docker, mailhog etc.');
+
+	/**
+	 * Delete an Nginx proxy config.
+	 */
+	$app->command('unproxy domain', function ($domain) {
+		Site::proxyDelete($domain);
+		Nginx::restart();
+	})->descriptions('Delete an Nginx proxy config.');
+
+	/**
+	 * Display all of the sites that are proxies.
+	 */
+	$app->command('proxies', function () {
+		$proxies = Site::proxies();
+
+		table(['Site', 'SSL', 'URL', 'Host'], $proxies->all());
+	})->descriptions('Display all of the proxy sites');
+
+	/**
+	 * Determine which Valet driver the current directory is using.
+	 */
+	$app->command('which', function () {
+		require __DIR__ . '/drivers/require.php';
+
+		$driver = ValetDriver::assign(getcwd(), basename(getcwd()), '/');
+
+		if ($driver) {
+			info('This site is served by [' . get_class($driver) . '].');
+		} else {
+			warning('Valet could not determine which driver to use for this site.');
+		}
+	})->descriptions('Determine which Valet driver serves the current working directory');
+
+	/**
+	 * Display all of the registered paths.
+	 */
+	$app->command('paths', function () {
+		$paths = Configuration::read()['paths'];
+
+		if (count($paths) > 0) {
+			output(json_encode($paths, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+		} else {
+			info('No paths have been registered.');
+		}
+	})->descriptions('Get all of the paths registered with Valet');
+
+	/**
+	 * Open the current or given directory in the browser.
+	 */
+	$app->command('open [domain]', function ($domain = null) {
+		$url = 'http://' . ($domain ?: Site::host(getcwd())) . '.' . Configuration::read()['tld'];
+		CommandLine::passthru("start $url");
+	})->descriptions('Open the site for the current (or specified) directory in your browser');
+
+	/**
+	 * Generate a publicly accessible URL for your project.
+	 */
+	// TODO: custom domain and ngrok params
+	$app->command(
+		'share [domain] [--authtoken=] [--host-header=] [--hostname=] [--region=] [--subdomain=]',
+		function ($domain = null, $authtoken = null, $hostheader = null, $hostname = null, $region = null, $subdomain = null) {
+			$url = ($domain ?: strtolower(Site::host(getcwd()))) . '.' . Configuration::read()['tld'];
+
+			Ngrok::start($url, Site::port($url), array_filter([
+				'authtoken' => $authtoken,
+				'host-header' => $hostheader,
+				'hostname' => $hostname,
+				'region' => $region,
+				'subdomain' => $subdomain,
+			]));
+		}
+	)->defaults([
+			'host-header' => 'rewrite',
+		])->descriptions('Generate a publicly accessible URL for your project');
+
+	/**
+	 * Echo the currently tunneled URL.
+	 */
+	$app->command('fetch-share-url [domain]', function ($domain = null) {
+		output(Ngrok::currentTunnelUrl($domain ?: Site::host(getcwd()) . '.' . Configuration::read()['tld']));
+	})->descriptions('Get the URL to the current Ngrok tunnel');
+
+	/**
+	 * Run ngrok commands.
+	 */
+	$app->command('ngrok [args]*', function ($args) {
+		Ngrok::run(implode(' ', $args));
+	})->descriptions('Run ngrok commands');
+
+	/**
+	 * Start the daemon services.
+	 */
+	$app->command('start [service]', function ($service) {
+		switch ($service) {
+			case '':
+				Acrylic::restart();
+				PhpCgi::restart();
+				PhpCgiXdebug::restart();
+				Nginx::restart();
+
+				return info('Valet services have been started.');
+			case 'acrylic':
+				Acrylic::restart();
+
+				return info('Acrylic DNS has been started.');
+			case 'nginx':
+				Nginx::restart();
+
+				return info('Nginx has been started.');
+			case 'php':
+				PhpCgi::restart();
+
+				return info('PHP has been started.');
+			case 'php-xdebug':
+				PhpCgiXdebug::restart();
+
+				return info('PHP Xdebug has been started.');
+		}
+
+		return warning(sprintf('Invalid valet service name [%s]', $service));
+	})->descriptions('Start the Valet services');
+
+	/**
+	 * Restart the daemon services.
+	 */
+	$app->command('restart [service]', function ($service) {
+		switch ($service) {
+			case '':
+				Acrylic::restart();
+				PhpCgi::restart();
+				PhpCgiXdebug::restart();
+				Nginx::restart();
+
+				return info('Valet services have been restarted.');
+			case 'acrylic':
+				Acrylic::restart();
+
+				return info('Acrylic DNS has been restarted.');
+			case 'nginx':
+				Nginx::restart();
+
+				return info('Nginx has been restarted.');
+			case 'php':
+				PhpCgi::restart();
+
+				return info('PHP has been restarted.');
+			case 'php-xdebug':
+				PhpCgiXdebug::restart();
+
+				return info('PHP Xdebug has been restarted.');
+		}
+
+		return warning(sprintf('Invalid valet service name [%s]', $service));
+	})->descriptions('Restart the Valet services');
+
+	/**
+	 * Stop the daemon services.
+	 */
+	$app->command('stop [service]', function ($service) {
+		switch ($service) {
+			case '':
+				Acrylic::stop();
+				Nginx::stop();
+				PhpCgi::stop();
+				PhpCgiXdebug::stop();
+
+				return info('Valet services have been stopped.');
+			case 'acrylic':
+				Acrylic::stop();
+
+				return info('Acrylic DNS has been stopped.');
+			case 'nginx':
+				Nginx::stop();
+
+				return info('Nginx has been stopped.');
+			case 'php':
+				PhpCgi::stop();
+
+				return info('PHP has been stopped.');
+			case 'php-xdebug':
+				PhpCgiXdebug::stop();
+
+				return info('PHP Xdebug has been stopped.');
+		}
+
+		return warning(sprintf('Invalid valet service name [%s]', $service));
+	})->descriptions('Stop the Valet services');
+
+	/**
+	 * Uninstall Valet entirely. Requires --force to actually remove; otherwise manual instructions are displayed.
+	 */
+	$app->command('uninstall [--force] [--purge-config]', function ($input, $output, $force, $purgeConfig) {
+		warning('YOU ARE ABOUT TO UNINSTALL Nginx, PHP-CGI, Acrylic DNS and all Valet configs and logs.');
+
+		$helper = $this->getHelperSet()->get('question');
+		$question = new ConfirmationQuestion("Are you sure you want to proceed? yes/no\n", false);
+		if (!$force && !$helper->ask($input, $output, $question)) {
+			return warning('Uninstall aborted.');
+		}
+
+		info('Stopping services...');
+
+		Acrylic::stop();
+		Nginx::stop();
+		PhpCgi::stop();
+		PhpCgiXdebug::stop();
+
+		if ($purgeConfig) {
+			info('Removing certificates for all secured sites...');
+			Site::unsecureAll();
+		} else {
+			Site::untrustCertificates();
+		}
+
+		info('Removing Nginx...');
+		Nginx::uninstall();
+
+		info('Removing Acrylic DNS...');
+		Acrylic::uninstall();
+
+		info('Removing PHP-CGI...');
+		PhpCgi::uninstall();
+
+		info('Removing PHP-CGI Xdebug...');
+		PhpCgiXdebug::uninstall();
+
+		if ($purgeConfig) {
+			info('Removing Valet configs...');
+			Configuration::uninstall();
+		}
+
+		info("\nValet has been removed from your system.");
+
+		output(
+			"\n<fg=yellow>NOTE:</>" .
+			"\nRemove composer dependency with: <info>composer global remove cretueusebiu/valet-windows</info>" .
+			($purgeConfig ? '' : "\nDelete the config files from: <info>~/.config/valet</info>") .
+			"\nDelete PHP from: <info>C:/php</info>"
+		);
+	})->descriptions('Uninstall the Valet services', ['--force' => 'Do a forceful uninstall of Valet']);
+
+	/**
+	 * Determine if this is the latest release of Valet.
+	 */
+	$app->command('on-latest-version', function () use ($version) {
+		if (Valet::onLatestVersion($version)) {
+			output('Yes');
+		} else {
+			output(sprintf('Your version of Valet (%s) is not the latest version available.', $version));
+			output('Upgrade instructions can be found in the docs: https://github.com/cretueusebiu/valet-windows#upgrading');
+		}
+	})->descriptions('Determine if this is the latest version of Valet');
+
+	/**
+	 * Install the sudoers.d entries so password is no longer required.
+	 */
+	$app->command('trust [--off]', function ($off) {
+		warning('This command is not required for Windows.');
+	})->descriptions('This command is not required for Windows.');
+
+	/**
+	 * Allow the user to change the version of php valet uses.
+	 *
+	 *  @param string $phpVersion can be 'default' or PHP version eg. 8.1.12
+	 */
+	$app->command('use [phpVersion] [--site=]', function ($phpVersion, $site) {
+		if (empty($phpVersion)) {
+			warning('Please enter a PHP version. Example command [valet use 7.3]');
+
+			return;
+		}
+
+		if ($site) {
+			Site::usePhp($phpVersion, $site);
+
+			return;
+		}
+
+		$php = Configuration::getPhpByVersion($phpVersion);
+
+		if (empty($php)) {
+			warning("Cannot find PHP [$phpVersion] in the list. Example command [valet use 7.3]");
+		}
+
+		info("Setting the default PHP version to [$phpVersion].");
+
+		Configuration::updateKey('default_php', $php['version']);
+
+		info('Stopping Nginx...');
+		Nginx::stop();
+
+		Nginx::installConfiguration();
+		Nginx::installServer();
+		Nginx::installNginxDirectory();
+		Nginx::installService();
+		Nginx::restart();
+
+		info(sprintf('Valet is now using %s.', $php['version']) . PHP_EOL);
+		info('Note that you might need to run <comment>composer global update</comment> if your PHP version change affects the dependencies of global packages required by Composer.');
+	})->descriptions('Change the version of PHP used by valet', [
+			'phpVersion' => 'The PHP version you want to use, e.g 7.3',
+			'--site' => 'Isolate PHP version of a specific valet site. e.g: --site=site.test',
+		]);
+
+	/**
+	 * Tail log file.
+	 */
+	$app->command('log [-f|--follow] [-l|--lines=] [key]', function ($follow, $lines, $key = null) {
+		$defaultLogs = [
+			'nginx' => VALET_HOME_PATH . '/Log/nginx-error.log',
+			'nginxservice.err' => VALET_HOME_PATH . '/Log/nginxservice.err.log',
+			'nginxservice.out' => VALET_HOME_PATH . '/Log/nginxservice.out.log',
+			'nginxservice.wrapper' => VALET_HOME_PATH . '/Log/nginxservice.wrapper.log',
+			'phpcgiservice.err' => VALET_HOME_PATH . '/Log/phpcgiservice.err.log',
+			'phpcgiservice.out' => VALET_HOME_PATH . '/Log/phpcgiservice.out.log',
+			'phpcgiservice.wrapper' => VALET_HOME_PATH . '/Log/phpcgiservice.wrapper.log',
+		];
+
+		$configLogs = data_get(Configuration::read(), 'logs');
+		if (!is_array($configLogs)) {
+			$configLogs = [];
+		}
+
+		$logs = array_merge($defaultLogs, $configLogs);
+		ksort($logs);
+
+		if (!$key) {
+			info(implode(PHP_EOL, [
+				'In order to tail a log, pass the relevant log key (e.g. "nginx")',
+				'along with any optional tail parameters (e.g. "-f" for follow).',
+				null,
+				'For example: "valet log nginx -f --lines=3"',
+				null,
+				'Here are the logs you might be interested in.',
+				null,
+			]));
+
+			table(
+				['Key', 'File'],
+				collect($logs)->map(function ($file, $key) {
+					return [$key, $file];
+				})->toArray()
+			);
+
+			info(implode(PHP_EOL, [
+				null,
+				'Tip: Set custom logs by adding a "logs" key/file object',
+				'to your "' . Configuration::path() . '" file.',
+			]));
+
+			exit;
+		}
+
+		if (!isset($logs[$key])) {
+			return warning('No logs found for [' . $key . '].');
+		}
+
+		$file = $logs[$key];
+		if (!file_exists($file)) {
+			return warning('Log path [' . $file . '] does not (yet) exist.');
+		}
+
+		$options = [];
+		if ($follow) {
+			$options[] = '-f';
+		}
+		if ((int) $lines) {
+			$options[] = '-n ' . (int) $lines;
+		}
+
+		$command = implode(' ', array_merge(['tail'], $options, [$file]));
+
+		passthru($command);
+	})->descriptions('Tail log file');
+
+	/**
+	 * List the installed Valet services.
+	 */
+	$app->command('services', function () {
+		table(['Service', 'Windows Name', 'Status'], Valet::services());
+		info('Use valet start/stop/restart [service] to change status (eg: valet restart nginx).');
+	})->descriptions('List the installed Windows services.');
+
+	/**
+	 * Configure or display the directory-listing setting.
+	 */
+	$app->command('directory-listing [status]', function ($status = null) {
+		$key = 'directory-listing';
+		$config = Configuration::read();
+
+		if (in_array($status, ['on', 'off'])) {
+			$config[$key] = $status;
+			Configuration::write($config);
+
+			return output('Directory listing setting is now: ' . $status);
+		}
+
+		$current = isset($config[$key]) ? $config[$key] : 'off';
+		output('Directory listing is ' . $current);
+	})->descriptions('Determine directory-listing behavior. Default is off, which means a 404 will display.', [
+			'status' => 'on or off. (default=off) will show a 404 page; [on] will display a listing if project folder exists but requested URI not found',
+		]);
+
+	/**
+	 * Output diagnostics to aid in debugging Valet.
+	 */
+	$app->command('diagnose [-p|--print] [--plain]', function ($print, $plain) {
+		info('Running diagnostics... (this may take a while)');
+
+		Diagnose::run($print, $plain);
+	})->descriptions('Output diagnostics to aid in debugging Valet.', [
+			'--print' => 'print diagnostics output while running',
+			'--plain' => 'format clipboard output as plain text',
+		]);
 }
 
 /**
  * Load all of the Valet extensions.
  */
 foreach (Valet::extensions() as $extension) {
-    include $extension;
+	include $extension;
 }
 
 /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -211,7 +211,7 @@ if (is_dir(VALET_HOME_PATH)) {
     $app->command('parked', function () {
         $parked = Site::parked();
 
-        table(['Site', 'SSL', 'URL', 'Path'], $parked->all());
+        table(['Site', 'SSL', 'PHP', 'URL', 'Path'], $parked->all());
     })->descriptions('Display all the current sites within parked paths');
 
 //    /**
@@ -252,7 +252,7 @@ if (is_dir(VALET_HOME_PATH)) {
     $app->command('links', function () {
         $links = Site::links();
 
-        table(['Site', 'SSL', 'Php', 'URL', 'Path'], $links->all());
+        table(['Site', 'SSL', 'PHP', 'URL', 'Path'], $links->all());
     })->descriptions('Display all of the registered Valet links');
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -127,6 +127,17 @@ $app->command('php:list', function () {
 })->descriptions('List all PHP services');
 
 /**
+ * Determines which PHP version the current working directory is using.
+ */
+$app->command('php:which', function () {
+
+	$which = Site::whichPhp(basename(getcwd()));
+
+	info("This site {$which['site']} is using PHP {$which['php']}");
+
+})->descriptions('Determine which PHP version the working directory is using');
+
+/**
  * Install PHP xDebug services.
  */
 $app->command('xdebug:install', function () {

--- a/server.php
+++ b/server.php
@@ -11,9 +11,9 @@ define('VALET_STATIC_PREFIX', '41c270e4-5535-4daa-b23e-c269744c2f45');
  */
 function show_valet_404()
 {
-    http_response_code(404);
-    require __DIR__.'/cli/templates/404.html';
-    exit;
+	http_response_code(404);
+	require __DIR__.'/cli/templates/404.html';
+	exit;
 }
 
 /**
@@ -21,29 +21,29 @@ function show_valet_404()
  */
 function show_directory_listing($valetSitePath, $uri)
 {
-    $is_root = ($uri == '/');
-    $directory = ($is_root) ? $valetSitePath : $valetSitePath.$uri;
+	$is_root = ($uri == '/');
+	$directory = ($is_root) ? $valetSitePath : $valetSitePath.$uri;
 
-    if (! file_exists($directory)) {
-        show_valet_404();
-    }
+	if (! file_exists($directory)) {
+		show_valet_404();
+	}
 
-    // Sort directories at the top
-    $paths = glob("$directory/*");
-    usort($paths, function ($a, $b) {
-        return (is_dir($a) == is_dir($b)) ? strnatcasecmp($a, $b) : (is_dir($a) ? -1 : 1);
-    });
+	// Sort directories at the top
+	$paths = glob("$directory/*");
+	usort($paths, function ($a, $b) {
+		return (is_dir($a) == is_dir($b)) ? strnatcasecmp($a, $b) : (is_dir($a) ? -1 : 1);
+	});
 
-    // Output the HTML for the directory listing
-    echo "<h1>Index of $uri</h1>";
-    echo '<hr>';
-    echo implode("<br>\n", array_map(function ($path) use ($uri, $is_root) {
-        $file = basename($path);
+	// Output the HTML for the directory listing
+	echo "<h1>Index of $uri</h1>";
+	echo '<hr>';
+	echo implode("<br>\n", array_map(function ($path) use ($uri, $is_root) {
+		$file = basename($path);
 
-        return ($is_root) ? "<a href='/$file'>/$file</a>" : "<a href='$uri/$file'>$uri/$file/</a>";
-    }, $paths));
+		return ($is_root) ? "<a href='/$file'>/$file</a>" : "<a href='$uri/$file'>$uri/$file/</a>";
+	}, $paths));
 
-    exit;
+	exit;
 }
 
 /**
@@ -53,34 +53,34 @@ function show_directory_listing($valetSitePath, $uri)
  */
 function valet_support_wildcard_dns($domain, $config)
 {
-    $services = [
-        '.*.*.*.*.xip.io',
-        '.*.*.*.*.nip.io',
-        '-*-*-*-*.nip.io',
-    ];
+	$services = [
+		'.*.*.*.*.xip.io',
+		'.*.*.*.*.nip.io',
+		'-*-*-*-*.nip.io',
+	];
 
-    if (isset($config['tunnel_services'])) {
-        $services = array_merge($services, (array) $config['tunnel_services']);
-    }
+	if (isset($config['tunnel_services'])) {
+		$services = array_merge($services, (array) $config['tunnel_services']);
+	}
 
-    $patterns = [];
-    foreach ($services as $service) {
-        $pattern = preg_quote($service, '#');
-        $pattern = str_replace('\*', '.*', $pattern);
-        $patterns[] = '(.*)'.$pattern;
-    }
+	$patterns = [];
+	foreach ($services as $service) {
+		$pattern = preg_quote($service, '#');
+		$pattern = str_replace('\*', '.*', $pattern);
+		$patterns[] = '(.*)'.$pattern;
+	}
 
-    $pattern = implode('|', $patterns);
+	$pattern = implode('|', $patterns);
 
-    if (preg_match('#(?:'.$pattern.')\z#u', $domain, $matches)) {
-        $domain = array_pop($matches);
-    }
+	if (preg_match('#(?:'.$pattern.')\z#u', $domain, $matches)) {
+		$domain = array_pop($matches);
+	}
 
-    if (strpos($domain, ':') !== false) {
-        $domain = explode(':', $domain)[0];
-    }
+	if (strpos($domain, ':') !== false) {
+		$domain = explode(':', $domain)[0];
+	}
 
-    return $domain;
+	return $domain;
 }
 
 /**
@@ -89,35 +89,35 @@ function valet_support_wildcard_dns($domain, $config)
  * */
 function valet_default_site_path($config)
 {
-    if (isset($config['default']) && is_string($config['default']) && is_dir($config['default'])) {
-        return $config['default'];
-    }
+	if (isset($config['default']) && is_string($config['default']) && is_dir($config['default'])) {
+		return $config['default'];
+	}
 
-    return null;
+	return null;
 }
 
 /**
  * Load the Valet configuration.
  */
 $valetConfig = json_decode(
-    file_get_contents(VALET_HOME_PATH.'/config.json'), true
+	file_get_contents(VALET_HOME_PATH.'/config.json'), true
 );
 
 /**
  * Parse the URI and site / host for the incoming request.
  */
 $uri = rawurldecode(
-    explode('?', $_SERVER['REQUEST_URI'])[0]
+	explode('?', $_SERVER['REQUEST_URI'])[0]
 );
 
 $siteName = basename(
-    // Filter host to support wildcard dns feature
-    valet_support_wildcard_dns($_SERVER['HTTP_HOST'], $valetConfig),
-    '.'.$valetConfig['tld']
+	// Filter host to support wildcard dns feature
+	valet_support_wildcard_dns($_SERVER['HTTP_HOST'], $valetConfig),
+	'.'.$valetConfig['tld']
 );
 
 if (strpos($siteName, 'www.') === 0) {
-    $siteName = substr($siteName, 4);
+	$siteName = substr($siteName, 4);
 }
 
 /**
@@ -126,49 +126,49 @@ if (strpos($siteName, 'www.') === 0) {
  */
 function get_valet_site_path($valetConfig, $siteName, $domain)
 {
-    $valetSitePath = null;
+	$valetSitePath = null;
 
-    foreach ($valetConfig['paths'] as $path) {
-        $handle = opendir($path);
+	foreach ($valetConfig['paths'] as $path) {
+		$handle = opendir($path);
 
-        if ($handle === false) {
-            continue;
-        }
+		if ($handle === false) {
+			continue;
+		}
 
-        $dirs = [];
+		$dirs = [];
 
-        while (false !== ($file = readdir($handle))) {
-            if (is_dir($path.'/'.$file) && ! in_array($file, ['.', '..'])) {
-                $dirs[] = $file;
-            }
-        }
+		while (false !== ($file = readdir($handle))) {
+			if (is_dir($path.'/'.$file) && ! in_array($file, ['.', '..'])) {
+				$dirs[] = $file;
+			}
+		}
 
-        closedir($handle);
+		closedir($handle);
 
-        // Note: strtolower used below because Nginx only tells us lowercase names
-        foreach ($dirs as $dir) {
-            if (strtolower($dir) === $siteName) {
-                // early return when exact match for linked subdomain
-                return $path.'/'.$dir;
-            }
+		// Note: strtolower used below because Nginx only tells us lowercase names
+		foreach ($dirs as $dir) {
+			if (strtolower($dir) === $siteName) {
+				// early return when exact match for linked subdomain
+				return $path.'/'.$dir;
+			}
 
-            if (strtolower($dir) === $domain) {
-                // no early return here because the foreach may still have some subdomains to process with higher priority
-                $valetSitePath = $path.'/'.$dir;
-            }
-        }
+			if (strtolower($dir) === $domain) {
+				// no early return here because the foreach may still have some subdomains to process with higher priority
+				$valetSitePath = $path.'/'.$dir;
+			}
+		}
 
-        if ($valetSitePath) {
-            return $valetSitePath;
-        }
-    }
+		if ($valetSitePath) {
+			return $valetSitePath;
+		}
+	}
 }
 
 $domain = array_slice(explode('.', $siteName), -1)[0];
 $valetSitePath = get_valet_site_path($valetConfig, $siteName, $domain);
 
 if (is_null($valetSitePath) && is_null($valetSitePath = valet_default_site_path($valetConfig))) {
-    show_valet_404();
+	show_valet_404();
 }
 
 $valetSitePath = realpath($valetSitePath);
@@ -183,28 +183,28 @@ require __DIR__.'/cli/drivers/require.php';
 $valetDriver = ValetDriver::assign($valetSitePath, $siteName, $uri);
 
 if (! $valetDriver) {
-    show_valet_404();
+	show_valet_404();
 }
 
 /*
  * Attempt to load server environment variables.
  */
 $valetDriver->loadServerEnvironmentVariables(
-    $valetSitePath, $siteName
+	$valetSitePath, $siteName
 );
 
 /**
  * ngrok uses the X-Original-Host to store the forwarded hostname.
  */
 if (isset($_SERVER['HTTP_X_ORIGINAL_HOST']) && ! isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
-    $_SERVER['HTTP_X_FORWARDED_HOST'] = $_SERVER['HTTP_X_ORIGINAL_HOST'];
+	$_SERVER['HTTP_X_FORWARDED_HOST'] = $_SERVER['HTTP_X_ORIGINAL_HOST'];
 }
 
 /**
  * Attempt to load server environment variables.
  */
 $valetDriver->loadServerEnvironmentVariables(
-    $valetSitePath, $siteName
+	$valetSitePath, $siteName
 );
 
 /**
@@ -218,22 +218,22 @@ $uri = $valetDriver->mutateUri($uri);
 $isPhpFile = pathinfo($uri, PATHINFO_EXTENSION) === 'php';
 
 if ($uri !== '/' && ! $isPhpFile && $staticFilePath = $valetDriver->isStaticFile($valetSitePath, $siteName, $uri)) {
-    return $valetDriver->serveStaticFile($staticFilePath, $valetSitePath, $siteName, $uri);
+	return $valetDriver->serveStaticFile($staticFilePath, $valetSitePath, $siteName, $uri);
 }
 
 /**
  * Attempt to dispatch to a front controller.
  */
 $frontControllerPath = $valetDriver->frontControllerPath(
-    $valetSitePath, $siteName, $uri
+	$valetSitePath, $siteName, $uri
 );
 
 if (! $frontControllerPath) {
-    if (isset($valetConfig['directory-listing']) && $valetConfig['directory-listing'] == 'on') {
-        show_directory_listing($valetSitePath, $uri);
-    }
+	if (isset($valetConfig['directory-listing']) && $valetConfig['directory-listing'] == 'on') {
+		show_directory_listing($valetSitePath, $uri);
+	}
 
-    show_valet_404();
+	show_valet_404();
 }
 
 chdir(dirname($frontControllerPath));

--- a/tests/AcrylicTest.php
+++ b/tests/AcrylicTest.php
@@ -11,92 +11,92 @@ use function Valet\resolve;
 
 class AcrylicTest extends TestCase
 {
-    /** @test */
-    public function install_acrylic_service()
-    {
-        $this->partialMock(Filesystem::class)
-            ->shouldReceive('put')->once()->andReturnUsing(function ($path, $contents) {
-                $this->assertSame($this->path('AcrylicHosts.txt'), $path);
-                $this->assertTrue(strpos($contents, 'test') !== false);
-                $this->assertTrue(strpos($contents, Valet::homePath()) !== false);
-            })
-            ->shouldReceive('exists')->with(Valet::homePath('AcrylicHosts.txt'))->once()->andReturn(false)
-            ->shouldReceive('putAsUser')->once()->andReturnUsing(function ($path, $contents) {
-                $this->assertSame(Valet::homePath('AcrylicHosts.txt'), $path);
-                $this->assertSame(PHP_EOL, $contents);
-            });
+	/** @test */
+	public function install_acrylic_service()
+	{
+		$this->partialMock(Filesystem::class)
+			->shouldReceive('put')->once()->andReturnUsing(function ($path, $contents) {
+				$this->assertSame($this->path('AcrylicHosts.txt'), $path);
+				$this->assertTrue(strpos($contents, 'test') !== false);
+				$this->assertTrue(strpos($contents, Valet::homePath()) !== false);
+			})
+			->shouldReceive('exists')->with(Valet::homePath('AcrylicHosts.txt'))->once()->andReturn(false)
+			->shouldReceive('putAsUser')->once()->andReturnUsing(function ($path, $contents) {
+				$this->assertSame(Valet::homePath('AcrylicHosts.txt'), $path);
+				$this->assertSame(PHP_EOL, $contents);
+			});
 
-        $this->mock(CommandLine::class)
-            ->shouldReceive('powershell')->once()->with('Get-Service -Name "AcrylicDNSProxySvc"')->andReturn(FakeProcessOutput::unsuccessfull())
-            ->shouldReceive('powershell')->once()->with('(Get-NetIPAddress -AddressFamily IPv4).InterfaceIndex | ForEach-Object {Set-DnsClientServerAddress -InterfaceIndex $_ -ServerAddresses (\"127.0.0.1\", \"8.8.8.8\")};(Get-NetIPAddress -AddressFamily IPv6).InterfaceIndex | ForEach-Object {Set-DnsClientServerAddress -InterfaceIndex $_ -ServerAddresses (\"::1\", \"2001:4860:4860::8888\")}')
-            ->shouldReceive('runOrExit')->once()->andReturnUsing(function ($command) {
-                $this->assertSame('cmd /C "'.$this->path('AcrylicUI.exe').'" InstallAcrylicService', $command);
-            })
-            ->shouldReceive('run')->once()->with('cmd "/C ipconfig /flushdns"');
+		$this->mock(CommandLine::class)
+			->shouldReceive('powershell')->once()->with('Get-Service -Name "AcrylicDNSProxySvc"')->andReturn(FakeProcessOutput::unsuccessfull())
+			->shouldReceive('powershell')->once()->with('(Get-NetIPAddress -AddressFamily IPv4).InterfaceIndex | ForEach-Object {Set-DnsClientServerAddress -InterfaceIndex $_ -ServerAddresses (\"127.0.0.1\", \"8.8.8.8\")};(Get-NetIPAddress -AddressFamily IPv6).InterfaceIndex | ForEach-Object {Set-DnsClientServerAddress -InterfaceIndex $_ -ServerAddresses (\"::1\", \"2001:4860:4860::8888\")}')
+			->shouldReceive('runOrExit')->once()->andReturnUsing(function ($command) {
+				$this->assertSame('cmd /C "'.$this->path('AcrylicUI.exe').'" InstallAcrylicService', $command);
+			})
+			->shouldReceive('run')->once()->with('cmd "/C ipconfig /flushdns"');
 
-        resolve(Acrylic::class)->install();
-    }
+		resolve(Acrylic::class)->install();
+	}
 
-    /** @test */
-    public function update_acrylic_tld()
-    {
-        $this->mock(CommandLine::class)
-            ->shouldReceive('run');
+	/** @test */
+	public function update_acrylic_tld()
+	{
+		$this->mock(CommandLine::class)
+			->shouldReceive('run');
 
-        $this->partialMock(Filesystem::class)
-            ->shouldReceive('put')->once()->andReturnUsing(function ($path, $contents) {
-                $this->assertTrue(strpos($contents, 'app') !== false);
-            })
-            ->shouldReceive('exists')->andReturn(true);
+		$this->partialMock(Filesystem::class)
+			->shouldReceive('put')->once()->andReturnUsing(function ($path, $contents) {
+				$this->assertTrue(strpos($contents, 'app') !== false);
+			})
+			->shouldReceive('exists')->andReturn(true);
 
-        resolve(Acrylic::class)->updateTld('app');
-    }
+		resolve(Acrylic::class)->updateTld('app');
+	}
 
-    /** @test */
-    public function start_acrylic_service()
-    {
-        $this->mock(CommandLine::class)
-            ->shouldReceive('runOrExit')->once()->andReturnUsing(function ($command) {
-                $this->assertSame('cmd /C "'.$this->path('AcrylicUI.exe').'" StartAcrylicService', $command);
-            })
-            ->shouldReceive('run')->once()->with('cmd "/C ipconfig /flushdns"');
+	/** @test */
+	public function start_acrylic_service()
+	{
+		$this->mock(CommandLine::class)
+			->shouldReceive('runOrExit')->once()->andReturnUsing(function ($command) {
+				$this->assertSame('cmd /C "'.$this->path('AcrylicUI.exe').'" StartAcrylicService', $command);
+			})
+			->shouldReceive('run')->once()->with('cmd "/C ipconfig /flushdns"');
 
-        resolve(Acrylic::class)->start();
-    }
+		resolve(Acrylic::class)->start();
+	}
 
-    /** @test */
-    public function restart_acrylic_service()
-    {
-        $this->mock(CommandLine::class)
-            ->shouldReceive('run')->once()->andReturnUsing(function ($command) {
-                $this->assertSame('cmd /C "'.$this->path('AcrylicUI.exe').'" RestartAcrylicService', $command);
-            })
-            ->shouldReceive('run')->once()->with('cmd "/C ipconfig /flushdns"');
+	/** @test */
+	public function restart_acrylic_service()
+	{
+		$this->mock(CommandLine::class)
+			->shouldReceive('run')->once()->andReturnUsing(function ($command) {
+				$this->assertSame('cmd /C "'.$this->path('AcrylicUI.exe').'" RestartAcrylicService', $command);
+			})
+			->shouldReceive('run')->once()->with('cmd "/C ipconfig /flushdns"');
 
-        resolve(Acrylic::class)->restart();
-    }
+		resolve(Acrylic::class)->restart();
+	}
 
-    /** @test */
-    public function uninstall_acrylic_service()
-    {
-        $this->mock(CommandLine::class)
-            ->shouldReceive('powershell')->once()->with('Get-Service -Name "AcrylicDNSProxySvc"')->andReturn(FakeProcessOutput::successfull())
-            ->shouldReceive('powershell')->once()->with('(Get-NetIPAddress -AddressFamily IPv4).InterfaceIndex | ForEach-Object {Set-DnsClientServerAddress -InterfaceIndex $_ -ResetServerAddresses};(Get-NetIPAddress -AddressFamily IPv6).InterfaceIndex | ForEach-Object {Set-DnsClientServerAddress -InterfaceIndex $_ -ResetServerAddresses}')
-            ->shouldReceive('run')->twice()
-            ->shouldReceive('run')->once()->andReturnUsing(function ($command) {
-                $this->assertSame('cmd /C "'.$this->path('AcrylicUI.exe').'" UninstallAcrylicService', $command);
-            })
-            ->shouldReceive('run')->once();
+	/** @test */
+	public function uninstall_acrylic_service()
+	{
+		$this->mock(CommandLine::class)
+			->shouldReceive('powershell')->once()->with('Get-Service -Name "AcrylicDNSProxySvc"')->andReturn(FakeProcessOutput::successfull())
+			->shouldReceive('powershell')->once()->with('(Get-NetIPAddress -AddressFamily IPv4).InterfaceIndex | ForEach-Object {Set-DnsClientServerAddress -InterfaceIndex $_ -ResetServerAddresses};(Get-NetIPAddress -AddressFamily IPv6).InterfaceIndex | ForEach-Object {Set-DnsClientServerAddress -InterfaceIndex $_ -ResetServerAddresses}')
+			->shouldReceive('run')->twice()
+			->shouldReceive('run')->once()->andReturnUsing(function ($command) {
+				$this->assertSame('cmd /C "'.$this->path('AcrylicUI.exe').'" UninstallAcrylicService', $command);
+			})
+			->shouldReceive('run')->once();
 
-        resolve(Acrylic::class)->uninstall();
-    }
+		resolve(Acrylic::class)->uninstall();
+	}
 
-    /**
-     * @param  string  $path
-     * @return string
-     */
-    protected function path(string $path = ''): string
-    {
-        return resolve(Acrylic::class)->path($path);
-    }
+	/**
+	 * @param  string  $path
+	 * @return string
+	 */
+	protected function path(string $path = ''): string
+	{
+		return resolve(Acrylic::class)->path($path);
+	}
 }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -10,175 +10,175 @@ use Valet\Valet;
 
 class ConfigurationTest extends TestCase
 {
-    /** @test */
-    public function configuration_directory_is_created_if_it_doesnt_exist()
-    {
-        $this->mock(Filesystem::class)
-            ->shouldReceive('ensureDirExists')->once()->with(preg_replace('~/valet$~', '', Valet::homePath()), user())
-            ->shouldReceive('isDir')->andReturn(false)
-            ->shouldReceive('ensureDirExists')->once()->with(Valet::homePath(), user());
+	/** @test */
+	public function configuration_directory_is_created_if_it_doesnt_exist()
+	{
+		$this->mock(Filesystem::class)
+			->shouldReceive('ensureDirExists')->once()->with(preg_replace('~/valet$~', '', Valet::homePath()), user())
+			->shouldReceive('isDir')->andReturn(false)
+			->shouldReceive('ensureDirExists')->once()->with(Valet::homePath(), user());
 
-        resolve(Configuration::class)->createConfigurationDirectory();
-    }
+		resolve(Configuration::class)->createConfigurationDirectory();
+	}
 
-    /** @test */
-    public function drivers_directory_is_created_with_sample_driver_if_it_doesnt_exist()
-    {
-        $this->partialMock(Filesystem::class)
-            ->shouldReceive('isDir')->with(Valet::homePath('Drivers'))->andReturn(false)
-            ->shouldReceive('mkdirAsUser')->with(Valet::homePath('Drivers'))
-            ->shouldReceive('putAsUser');
+	/** @test */
+	public function drivers_directory_is_created_with_sample_driver_if_it_doesnt_exist()
+	{
+		$this->partialMock(Filesystem::class)
+			->shouldReceive('isDir')->with(Valet::homePath('Drivers'))->andReturn(false)
+			->shouldReceive('mkdirAsUser')->with(Valet::homePath('Drivers'))
+			->shouldReceive('putAsUser');
 
-        resolve(Configuration::class)->createDriversDirectory();
-    }
+		resolve(Configuration::class)->createDriversDirectory();
+	}
 
-    /** @test */
-    public function sites_directory_is_created_if_it_doesnt_exist()
-    {
-        $this->mock(Filesystem::class)
-            ->shouldReceive('ensureDirExists')->once()->with(Valet::homePath('Sites'), user());
+	/** @test */
+	public function sites_directory_is_created_if_it_doesnt_exist()
+	{
+		$this->mock(Filesystem::class)
+			->shouldReceive('ensureDirExists')->once()->with(Valet::homePath('Sites'), user());
 
-        resolve(Configuration::class)->createSitesDirectory();
-    }
+		resolve(Configuration::class)->createSitesDirectory();
+	}
 
-    /** @test */
-    public function extensions_directory_is_created_if_it_doesnt_exist()
-    {
-        $this->mock(Filesystem::class)
-            ->shouldReceive('ensureDirExists')->once()->with(Valet::homePath('Extensions'), user());
+	/** @test */
+	public function extensions_directory_is_created_if_it_doesnt_exist()
+	{
+		$this->mock(Filesystem::class)
+			->shouldReceive('ensureDirExists')->once()->with(Valet::homePath('Extensions'), user());
 
-        resolve(Configuration::class)->createExtensionsDirectory();
-    }
+		resolve(Configuration::class)->createExtensionsDirectory();
+	}
 
-    /** @test */
-    public function log_directory_is_created_with_log_files_if_it_doesnt_exist()
-    {
-        $this->mock(Filesystem::class)
-            ->shouldReceive('ensureDirExists')->once()->with(Valet::homePath('Log'), user())
-            ->shouldReceive('touch')->once()->with(Valet::homePath('Log\nginx-error.log'));
+	/** @test */
+	public function log_directory_is_created_with_log_files_if_it_doesnt_exist()
+	{
+		$this->mock(Filesystem::class)
+			->shouldReceive('ensureDirExists')->once()->with(Valet::homePath('Log'), user())
+			->shouldReceive('touch')->once()->with(Valet::homePath('Log\nginx-error.log'));
 
-        resolve(Configuration::class)->createLogDirectory();
-    }
+		resolve(Configuration::class)->createLogDirectory();
+	}
 
-    /** @test */
-    public function certificates_directory_is_created_if_it_doesnt_exist()
-    {
-        $this->mock(Filesystem::class)
-            ->shouldReceive('ensureDirExists')->once()->with(Valet::homePath('Certificates'), user());
+	/** @test */
+	public function certificates_directory_is_created_if_it_doesnt_exist()
+	{
+		$this->mock(Filesystem::class)
+			->shouldReceive('ensureDirExists')->once()->with(Valet::homePath('Certificates'), user());
 
-        resolve(Configuration::class)->createCertificatesDirectory();
-    }
+		resolve(Configuration::class)->createCertificatesDirectory();
+	}
 
-    /** @test */
-    public function services_directory_is_created_if_it_doesnt_exist()
-    {
-        $this->mock(Filesystem::class)
-            ->shouldReceive('ensureDirExists')->once()->with(Valet::homePath('Services'), user());
+	/** @test */
+	public function services_directory_is_created_if_it_doesnt_exist()
+	{
+		$this->mock(Filesystem::class)
+			->shouldReceive('ensureDirExists')->once()->with(Valet::homePath('Services'), user());
 
-        resolve(Configuration::class)->createServicesDirectory();
-    }
+		resolve(Configuration::class)->createServicesDirectory();
+	}
 
-    /** @test */
-    public function xdebug_directory_is_created_if_it_doesnt_exist()
-    {
-        $this->mock(Filesystem::class)
-            ->shouldReceive('ensureDirExists')->once()->with(Valet::homePath('Xdebug'), user());
+	/** @test */
+	public function xdebug_directory_is_created_if_it_doesnt_exist()
+	{
+		$this->mock(Filesystem::class)
+			->shouldReceive('ensureDirExists')->once()->with(Valet::homePath('Xdebug'), user());
 
-        resolve(Configuration::class)->createXdebugDirectory();
-    }
+		resolve(Configuration::class)->createXdebugDirectory();
+	}
 
-    /** @test */
-    public function base_configuration_is_created_if_it_doesnt_exist()
-    {
-        $this->mock(Filesystem::class)
-            ->shouldReceive('exists')->andReturn(false)
-            ->shouldReceive('putAsUser')
-            ->shouldReceive('get')->andReturn(json_encode(['tld' => 'test', 'php_port' => 9001]));
+	/** @test */
+	public function base_configuration_is_created_if_it_doesnt_exist()
+	{
+		$this->mock(Filesystem::class)
+			->shouldReceive('exists')->andReturn(false)
+			->shouldReceive('putAsUser')
+			->shouldReceive('get')->andReturn(json_encode(['tld' => 'test', 'php_port' => 9001]));
 
-        resolve(Configuration::class)->writeBaseConfiguration();
-    }
+		resolve(Configuration::class)->writeBaseConfiguration();
+	}
 
-    /** @test */
-    public function add_path_adds_a_path_to_the_paths_array_and_removes_duplicates()
-    {
-        $this->mock(Filesystem::class)
-            ->shouldReceive('get')->andReturn(json_encode([
-                'paths' => ['path-1', 'path-2'],
-            ]))
-            ->shouldReceive('putAsUser')->with(Valet::homePath('config.json'), json_encode(
-                ['paths' => ['path-1', 'path-2', 'path-3']],
-                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
-            ).PHP_EOL);
+	/** @test */
+	public function add_path_adds_a_path_to_the_paths_array_and_removes_duplicates()
+	{
+		$this->mock(Filesystem::class)
+			->shouldReceive('get')->andReturn(json_encode([
+				'paths' => ['path-1', 'path-2'],
+			]))
+			->shouldReceive('putAsUser')->with(Valet::homePath('config.json'), json_encode(
+				['paths' => ['path-1', 'path-2', 'path-3']],
+				JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+			).PHP_EOL);
 
-        resolve(Configuration::class)->addPath('path-3');
+		resolve(Configuration::class)->addPath('path-3');
 
-        $this->mock(Filesystem::class)
-            ->shouldReceive('get')->andReturn(json_encode([
-                'paths' => ['path-1', 'path-2', 'path-3'],
-            ]))
-            ->shouldReceive('putAsUser')->with(Valet::homePath('config.json'), json_encode(
-                ['paths' => ['path-1', 'path-2', 'path-3']],
-                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
-            ).PHP_EOL);
+		$this->mock(Filesystem::class)
+			->shouldReceive('get')->andReturn(json_encode([
+				'paths' => ['path-1', 'path-2', 'path-3'],
+			]))
+			->shouldReceive('putAsUser')->with(Valet::homePath('config.json'), json_encode(
+				['paths' => ['path-1', 'path-2', 'path-3']],
+				JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+			).PHP_EOL);
 
-        resolve(Configuration::class)->addPath('path-3');
-    }
+		resolve(Configuration::class)->addPath('path-3');
+	}
 
-    /** @test */
-    public function paths_may_be_removed_from_the_configuration()
-    {
-        $this->mock(Filesystem::class)
-            ->shouldReceive('get')->andReturn(json_encode([
-                'paths' => ['path-1', 'path-2'],
-            ]))
-            ->shouldReceive('putAsUser')->with(Valet::homePath('config.json'), json_encode(
-                ['paths' => ['path-1']],
-                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
-            ).PHP_EOL);
+	/** @test */
+	public function paths_may_be_removed_from_the_configuration()
+	{
+		$this->mock(Filesystem::class)
+			->shouldReceive('get')->andReturn(json_encode([
+				'paths' => ['path-1', 'path-2'],
+			]))
+			->shouldReceive('putAsUser')->with(Valet::homePath('config.json'), json_encode(
+				['paths' => ['path-1']],
+				JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+			).PHP_EOL);
 
-        resolve(Configuration::class)->removePath('path-2');
-    }
+		resolve(Configuration::class)->removePath('path-2');
+	}
 
-    /** @test */
-    public function prune_removes_directories_from_paths_that_no_longer_exist()
-    {
-        $this->mock(Filesystem::class)
-            ->shouldReceive('exists')->with(Valet::homePath('config.json'))->andReturn(true)
-            ->shouldReceive('get')->andReturn(json_encode([
-                'paths' => ['path-1', 'path-2'],
-            ]))
-            ->shouldReceive('isDir')->with('path-1')->andReturn(true)
-            ->shouldReceive('isDir')->with('path-2')->andReturn(false)
-            ->shouldReceive('putAsUser')->with(Valet::homePath('config.json'), json_encode(
-                ['paths' => ['path-1']],
-                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
-            ).PHP_EOL);
+	/** @test */
+	public function prune_removes_directories_from_paths_that_no_longer_exist()
+	{
+		$this->mock(Filesystem::class)
+			->shouldReceive('exists')->with(Valet::homePath('config.json'))->andReturn(true)
+			->shouldReceive('get')->andReturn(json_encode([
+				'paths' => ['path-1', 'path-2'],
+			]))
+			->shouldReceive('isDir')->with('path-1')->andReturn(true)
+			->shouldReceive('isDir')->with('path-2')->andReturn(false)
+			->shouldReceive('putAsUser')->with(Valet::homePath('config.json'), json_encode(
+				['paths' => ['path-1']],
+				JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+			).PHP_EOL);
 
-        resolve(Configuration::class)->prune();
-    }
+		resolve(Configuration::class)->prune();
+	}
 
-    /** @test */
-    public function prune_doesnt_execute_if_configuration_directory_doesnt_exist()
-    {
-        $this->mock(Filesystem::class)
-            ->shouldReceive('exists')->with(Valet::homePath('config.json'))->andReturn(false)
-            ->shouldReceive('get')->never()
-            ->shouldReceive('putAsUser')->never();
+	/** @test */
+	public function prune_doesnt_execute_if_configuration_directory_doesnt_exist()
+	{
+		$this->mock(Filesystem::class)
+			->shouldReceive('exists')->with(Valet::homePath('config.json'))->andReturn(false)
+			->shouldReceive('get')->never()
+			->shouldReceive('putAsUser')->never();
 
-        resolve(Configuration::class)->prune();
-    }
+		resolve(Configuration::class)->prune();
+	}
 
-    /** @test */
-    public function update_key_updates_the_specified_configuration_key()
-    {
-        $this->mock(Filesystem::class)
-            ->shouldReceive('exists')->with(Valet::homePath('config.json'))->andReturn(true)
-            ->shouldReceive('get')->andReturn(json_encode(['foo' => 'bar']))
-            ->shouldReceive('putAsUser')->with(Valet::homePath('config.json'), json_encode(
-                ['foo' => 'bar', 'bar' => 'baz'],
-                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
-            ).PHP_EOL);
+	/** @test */
+	public function update_key_updates_the_specified_configuration_key()
+	{
+		$this->mock(Filesystem::class)
+			->shouldReceive('exists')->with(Valet::homePath('config.json'))->andReturn(true)
+			->shouldReceive('get')->andReturn(json_encode(['foo' => 'bar']))
+			->shouldReceive('putAsUser')->with(Valet::homePath('config.json'), json_encode(
+				['foo' => 'bar', 'bar' => 'baz'],
+				JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+			).PHP_EOL);
 
-        resolve(Configuration::class)->updateKey('bar', 'baz');
-    }
+		resolve(Configuration::class)->updateKey('bar', 'baz');
+	}
 }

--- a/tests/FilesystemTest.php
+++ b/tests/FilesystemTest.php
@@ -6,25 +6,25 @@ use Valet\Filesystem;
 
 class FilesystemTest extends TestCase
 {
-    public function tearDown(): void
-    {
-        parent::tearDown();
+	public function tearDown(): void
+	{
+		parent::tearDown();
 
-        exec('cmd /C rmdir /s /q "'.__DIR__.DIRECTORY_SEPARATOR.'output"');
-        mkdir(__DIR__.'/output');
-        touch(__DIR__.'/output/.gitkeep');
-    }
+		exec('cmd /C rmdir /s /q "'.__DIR__.DIRECTORY_SEPARATOR.'output"');
+		mkdir(__DIR__.'/output');
+		touch(__DIR__.'/output/.gitkeep');
+	}
 
-    /** @test */
-    public function remove_broken_links_removes_broken_symlinks()
-    {
-        $files = new Filesystem();
+	/** @test */
+	public function remove_broken_links_removes_broken_symlinks()
+	{
+		$files = new Filesystem();
 
-        file_put_contents(__DIR__.'/output/file.out', 'test');
-        symlink(__DIR__.'/output/file.out', __DIR__.'/output/file.link');
-        $this->assertFileExists(__DIR__.'/output/file.link');
-        unlink(__DIR__.'/output/file.out');
-        $files->removeBrokenLinksAt(__DIR__.'/output');
-        $this->assertFileDoesNotExist(__DIR__.'/output/file.link');
-    }
+		file_put_contents(__DIR__.'/output/file.out', 'test');
+		symlink(__DIR__.'/output/file.out', __DIR__.'/output/file.link');
+		$this->assertFileExists(__DIR__.'/output/file.link');
+		unlink(__DIR__.'/output/file.out');
+		$files->removeBrokenLinksAt(__DIR__.'/output');
+		$this->assertFileDoesNotExist(__DIR__.'/output/file.link');
+	}
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -10,460 +10,460 @@ use Tests\Support\DockerContainer;
  */
 class IntegrationTest extends TestCase
 {
-    /**
-     * @var \Tests\Support\DockerContainerInstance
-     */
-    protected $container;
-
-    public function setUp(): void
-    {
-        $this->container = DockerContainer::create('cretueusebiu/valet-windows')
-            ->command('ping -t localhost')
-            ->start();
-    }
-
-    public function tearDown(): void
-    {
-        if ($this->container) {
-            $this->container->stop();
-        }
-    }
-
-    /** @test */
-    public function install_valet()
-    {
-        // $this->container->exec('valet install')
-        //     ->assertSuccessful()
-        //     ->assertContains('Valet installed successfully');
-
-        $this->container->exec('Get-Service -Name "valet_nginx"')
-            ->assertSuccessful()
-            ->assertContains('Running  valet_nginx');
-
-        $this->container->exec('Get-Service -Name "valet_phpcgi"')
-            ->assertSuccessful()
-            ->assertContains('Running  valet_phpcgi');
-
-        $this->container->exec('Get-Service -Name "AcrylicDNSProxySvc"')
-            ->assertSuccessful()
-            ->assertContains('Running  AcrylicDNSProxySvc');
-
-        $this->container->exec('curl.exe --max-time 5 http://localhost')
-            ->assertSuccessful()
-            ->assertContains('<title>Valet - Not Found</title>');
-
-        $this->container->exec('valet')
-            ->assertSuccessful();
-
-        $this->container->exec('ls ~/.config/valet')
-            ->assertContains('Certificates')
-            ->assertContains('Drivers')
-            ->assertContains('Extensions')
-            ->assertContains('Log')
-            ->assertContains('Nginx')
-            ->assertContains('Sites')
-            ->assertContains('AcrylicHosts.txt')
-            ->assertContains('config.json');
-    }
-
-    /** @test */
-    public function configure_tld()
-    {
-        // $this->container->exec('valet install')->assertSuccessful();
-
-        $this->container->exec('valet tld')
-            ->assertSuccessful()
-            ->assertContains('test');
-
-        $this->container->exec('valet tld foo')
-            ->assertSuccessful()
-            ->assertContains('Your Valet TLD has been updated to [foo].');
-
-        $this->container->exec('cat ~/.config/valet/config.json')
-            ->assertSuccessful()
-            ->decodeOuputJson()
-            ->assertFragment(['tld' => 'foo']);
-    }
-
-    /** @test */
-    public function park_directory()
-    {
-        // $this->container->exec('valet install')->assertSuccessful();
-
-        $this->container->exec('mkdir C:/Code')
-            ->assertSuccessful();
-
-        $this->container->exec('valet park C:/Code')
-            ->assertSuccessful()
-            ->assertContains('The [C:/Code] directory has been added to Valet\'s paths.');
-
-        $this->container->exec('cat ~/.config/valet/config.json')
-            ->assertSuccessful()
-            ->decodeOuputJson()
-            ->assertFragment(['paths' => ['C:/Code']]);
-
-        $this->container->exec([
-            'mkdir C:/Code/laravel',
-            "Set-Content -Path 'C:/Code/laravel/index.html' -Value 'hello world'",
-        ])
-            ->assertSuccessful();
-
-        $this->container->exec('curl.exe --max-time 5 http://laravel.test')
-            ->assertSuccessful()
-            ->assertContains('hello world');
-    }
-
-    /** @test */
-    public function list_sites_within_parked_paths()
-    {
-        // $this->container->exec('valet install')->assertSuccessful();
-
-        $this->container->exec('mkdir C:/Code/laravel')
-            ->assertSuccessful();
-
-        $this->container->exec('valet park C:/Code')
-            ->assertSuccessful();
-
-        $this->container->exec('valet parked')
-            ->assertSuccessful()
-            ->assertContains('| laravel |     | http://laravel.test | C:\Code\laravel |');
-    }
-
-    /** @test */
-    public function forget_parked_path()
-    {
-        // $this->container->exec('valet install')->assertSuccessful();
-
-        $this->container->exec('mkdir C:/Code')
-            ->assertSuccessful();
-
-        $this->container->exec('valet park C:/Code')
-            ->assertSuccessful();
-
-        $this->container->exec('valet forget C:/Code')
-            ->assertSuccessful()
-            ->assertContains('The [C:/Code] directory has been removed from Valet\'s paths.');
-
-        $this->container->exec('cat ~/.config/valet/config.json')
-            ->assertSuccessful()
-            ->decodeOuputJson()
-            ->assertFragment(['paths' => []]);
-    }
-
-    /** @test */
-    public function add_symbolic_link()
-    {
-        // $this->container->exec('valet install')->assertSuccessful();
-
-        $this->container->exec('mkdir C:/Code/laravel')
-            ->assertSuccessful();
-
-        $this->container->exec('cd C:/Code/laravel; valet link laravel-api')
-            ->assertSuccessful()
-            ->assertContains('A [laravel-api] symbolic link has been created in [C:/Users/ContainerAdministrator/.config/valet/Sites/laravel-api].');
-
-        $this->container->exec('cat ~/.config/valet/config.json')
-            ->assertSuccessful()
-            ->decodeOuputJson()
-            ->assertFragment(['paths' => ['C:/Users/ContainerAdministrator/.config/valet/Sites']]);
-
-        $this->container->exec('Get-Item -Path ~/.config/valet/Sites/laravel-api')
-            ->assertSuccessful()
-            ->assertContains('d----l');
-
-        $this->container->exec([
-            'cd C:/Code/laravel',
-            "Set-Content -Path 'C:/Code/laravel/index.html' -Value 'hello world'",
-        ])
-            ->assertSuccessful();
-
-        $this->container->exec('curl.exe --max-time 5 http://laravel-api.test')
-            ->assertSuccessful()
-            ->assertContains('hello world');
-    }
-
-    /** @test */
-    public function list_symbolic_links()
-    {
-        // $this->container->exec('valet install')->assertSuccessful();
-
-        $this->container->exec('mkdir C:/Code/laravel')
-            ->assertSuccessful();
-
-        $this->container->exec('cd C:/Code/laravel; valet link laravel-api')
-            ->assertSuccessful();
-
-        $this->container->exec('valet links')
-            ->assertSuccessful()
-            ->assertContains('| laravel-api |     | http://laravel-api.test | C:\Code\laravel |');
-    }
-
-    /** @test */
-    public function remove_symbolic_link()
-    {
-        // $this->container->exec('valet install')->assertSuccessful();
-
-        $this->container->exec('mkdir C:/Code/laravel')
-            ->assertSuccessful();
-
-        $this->container->exec('cd C:/Code/laravel; valet link laravel-api')
-            ->assertSuccessful();
-
-        $this->container->exec('valet unlink laravel-api')
-            ->assertSuccessful()
-            ->assertContains('The [laravel-api] symbolic link has been removed.');
-
-        $this->container->exec('valet links')
-            ->assertSuccessful()
-            ->assertNotContains('laravel-api');
-    }
-
-    /** @test */
-    public function secure_domain()
-    {
-        // $this->container->exec('valet install')->assertSuccessful();
-
-        $this->container->exec('valet secure laravel')
-            ->assertSuccessful()
-            ->assertContains('The [laravel.test] site has been secured with a fresh TLS certificate.');
-
-        $this->container->exec('ls ~/.config/valet/Certificates')
-            ->assertContains('laravel.test.crt')
-            ->assertContains('laravel.test.csr')
-            ->assertContains('laravel.test.key');
-
-        $this->container->exec('Test-Path ~/.config/valet/Nginx/laravel.test.conf')
-            ->assertSuccessful()
-            ->assertContains('True');
-
-        $this->container->exec([
-            'mkdir C:/Code/laravel', 'cd C:/Code/laravel', 'valet link',
-            "Set-Content -Path 'C:/Code/laravel/index.html' -Value 'hello world'",
-        ])
-            ->assertSuccessful();
-
-        $this->container->exec('curl.exe --max-time 5 https://laravel.test')
-            ->assertSuccessful()
-            ->assertContains('hello world');
-
-        $this->container->exec('curl.exe -I --max-time 5 http://laravel.test')
-            ->assertSuccessful()
-            ->assertContains('HTTP/1.1 302 Moved Temporarily')
-            ->assertContains('Location: https://laravel.test/');
-    }
-
-    /** @test */
-    public function unsecure_domain()
-    {
-        // $this->container->exec('valet install')->assertSuccessful();
-
-        $this->container->exec([
-            'mkdir C:/Code/laravel', 'cd C:/Code/laravel', 'valet link',
-            "Set-Content -Path 'C:/Code/laravel/index.html' -Value 'hello world'",
-        ])
-            ->assertSuccessful();
-
-        $this->container->exec('valet secure laravel')
-            ->assertSuccessful();
-
-        $this->container->exec('valet unsecure laravel')
-            ->assertSuccessful()
-            ->assertContains('The [laravel.test] site will now serve traffic over HTTP.');
-
-        $this->container->exec('Test-Path ~/.config/valet/Nginx/laravel.test.conf')
-            ->assertSuccessful()
-            ->assertContains('False');
-
-        $this->container->exec('curl.exe --max-time 5 http://laravel.test')
-            ->assertSuccessful()
-            ->assertContains('hello world');
-
-        $this->container->exec('curl.exe --max-time 5 https://laravel.test')
-            ->assertContains('Failed to connect to laravel.test port 443');
-    }
-
-    /** @test */
-    public function unsecure_all_domains()
-    {
-        // $this->container->exec('valet install')->assertSuccessful();
-
-        $this->container->exec([
-            'mkdir C:/Code/laravel1',
-            'mkdir C:/Code/laravel2',
-            'valet park C:/Code',
-            'valet secure laravel1',
-            'valet secure laravel2',
-        ])
-            ->assertSuccessful();
-
-        $this->container->exec('valet unsecure --all')
-            ->assertSuccessful()
-            ->assertContains('unsecure --all was successful');
-
-        $this->container->exec('Test-Path ~/.config/valet/Nginx/laravel1.test.conf')
-            ->assertSuccessful()
-            ->assertContains('False');
-
-        $this->container->exec('Test-Path ~/.config/valet/Nginx/laravel2.test.conf')
-            ->assertSuccessful()
-            ->assertContains('False');
-    }
-
-    /** @test */
-    public function proxying_services()
-    {
-        // $this->container->exec('valet install')->assertSuccessful();
-
-        $this->container->exec('valet proxy elasticsearch http://127.0.0.1:9200')
-            ->assertSuccessful()
-            ->assertContains('Valet will now proxy [https://elasticsearch.test] traffic to [http://127.0.0.1:9200].');
-
-        $this->container->exec('Test-Path ~/.config/valet/Nginx/elasticsearch.test.conf')
-            ->assertSuccessful()
-            ->assertContains('True');
-
-        $this->container->exec('valet proxies')
-            ->assertSuccessful()
-            ->assertContains('| elasticsearch |  X  | https://elasticsearch.test | http://127.0.0.1:9200 |');
-
-        $this->container->exec('valet unproxy elasticsearch')
-            ->assertSuccessful()
-            ->assertContains('Valet will no longer proxy [https://elasticsearch.test].');
-
-        $this->container->exec('Test-Path ~/.config/valet/Nginx/elasticsearch.test.conf')
-            ->assertSuccessful()
-            ->assertContains('False');
-    }
-
-    /** @test */
-    public function determine_valet_driver()
-    {
-        // $this->container->exec('valet install')->assertSuccessful();
-
-        $this->container->exec([
-            'mkdir C:/Code/laravel',
-            "Set-Content -Path 'C:/Code/laravel/index.html' -Value 'hello world'",
-        ])
-            ->assertSuccessful();
-
-        $this->container->exec('cd C:/Code/laravel; valet which')
-            ->assertSuccessful()
-            ->assertContains('This site is served by [BasicValetDriver].');
-    }
-
-    /** @test */
-    public function list_paths()
-    {
-        // $this->container->exec('valet install')->assertSuccessful();
-
-        $this->container->exec([
-            'mkdir C:/Code',
-            'valet park C:/Code',
-        ])
-            ->assertSuccessful();
-
-        $this->container->exec('valet paths')
-            ->assertSuccessful()
-            ->assertContains('"C:/Code"');
-    }
-
-    /** @test */
-    public function start_daemon_services()
-    {
-        // $this->container->exec('valet install')->assertSuccessful();
-
-        $this->container->exec([
-            'Stop-Service -Name "valet_nginx"',
-            'Stop-Service -Name "valet_phpcgi"',
-            'Stop-Service -Name "AcrylicDNSProxySvc"',
-        ])
-            ->assertSuccessful();
-
-        $this->container->exec('valet start')
-            ->assertSuccessful()
-            ->assertContains('Valet services have been started.');
-
-        $this->container->exec('Get-Service -Name "valet_nginx"')
-            ->assertSuccessful()
-            ->assertContains('Running  valet_nginx');
-
-        $this->container->exec('Get-Service -Name "valet_phpcgi"')
-            ->assertSuccessful()
-            ->assertContains('Running  valet_phpcgi');
-
-        $this->container->exec('Get-Service -Name "AcrylicDNSProxySvc"')
-            ->assertSuccessful()
-            ->assertContains('Running  AcrylicDNSProxySvc');
-
-        $this->container->exec('valet start acrylic')
-            ->assertSuccessful()
-            ->assertContains('Acrylic DNS has been started.');
-
-        $this->container->exec('valet start nginx')
-            ->assertSuccessful()
-            ->assertContains('Nginx has been started.');
-
-        $this->container->exec('valet start php')
-            ->assertSuccessful()
-            ->assertContains('PHP has been started.');
-    }
-
-    /** @test */
-    public function stop_daemon_services()
-    {
-        $this->container->exec('valet stop')
-            ->assertSuccessful()
-            ->assertContains('Valet services have been stopped.');
-
-        $this->container->exec('Get-Service -Name "valet_nginx"')
-            ->assertSuccessful()
-            ->assertContains('Stopped  valet_nginx');
-
-        $this->container->exec('Get-Service -Name "valet_phpcgi"')
-            ->assertSuccessful()
-            ->assertContains('Stopped  valet_phpcgi');
-
-        $this->container->exec('Get-Service -Name "AcrylicDNSProxySvc"')
-            ->assertSuccessful()
-            ->assertContains('Stopped  AcrylicDNSProxySvc');
-
-        $this->container->exec('valet stop acrylic')
-            ->assertSuccessful()
-            ->assertContains('Acrylic DNS has been stopped.');
-
-        $this->container->exec('valet stop nginx')
-            ->assertSuccessful()
-            ->assertContains('Nginx has been stopped.');
-
-        $this->container->exec('valet stop php')
-            ->assertSuccessful()
-            ->assertContains('PHP has been stopped.');
-    }
-
-    /** @test */
-    public function uninstall_valet()
-    {
-        // $this->container->exec('valet install')->assertSuccessful();
-
-        $this->container->exec('valet uninstall --force')
-            ->assertSuccessful()
-            ->assertContains('Valet has been removed from your system.');
-
-        $this->container->exec('Get-Service -Name "valet_nginx"')
-            ->assertContains("Cannot find any service with service name 'valet_nginx'");
-
-        $this->container->exec('Get-Service -Name "valet_phpcgi"')
-            ->assertContains("Cannot find any service with service name 'valet_phpcgi'");
-
-        $this->container->exec('Get-Service -Name "AcrylicDNSProxySvc"')
-            ->assertContains("Cannot find any service with service name 'AcrylicDNSProxySvc'");
-
-        $this->container->exec('Test-Path ~/.config/valet')
-            ->assertContains('True');
-
-        $this->container->exec('valet uninstall --force --purge-config');
-
-        $this->container->exec('Test-Path ~/.config/valet')
-            ->assertContains('False');
-    }
+	/**
+	 * @var \Tests\Support\DockerContainerInstance
+	 */
+	protected $container;
+
+	public function setUp(): void
+	{
+		$this->container = DockerContainer::create('cretueusebiu/valet-windows')
+			->command('ping -t localhost')
+			->start();
+	}
+
+	public function tearDown(): void
+	{
+		if ($this->container) {
+			$this->container->stop();
+		}
+	}
+
+	/** @test */
+	public function install_valet()
+	{
+		// $this->container->exec('valet install')
+		//     ->assertSuccessful()
+		//     ->assertContains('Valet installed successfully');
+
+		$this->container->exec('Get-Service -Name "valet_nginx"')
+			->assertSuccessful()
+			->assertContains('Running  valet_nginx');
+
+		$this->container->exec('Get-Service -Name "valet_phpcgi"')
+			->assertSuccessful()
+			->assertContains('Running  valet_phpcgi');
+
+		$this->container->exec('Get-Service -Name "AcrylicDNSProxySvc"')
+			->assertSuccessful()
+			->assertContains('Running  AcrylicDNSProxySvc');
+
+		$this->container->exec('curl.exe --max-time 5 http://localhost')
+			->assertSuccessful()
+			->assertContains('<title>Valet - Not Found</title>');
+
+		$this->container->exec('valet')
+			->assertSuccessful();
+
+		$this->container->exec('ls ~/.config/valet')
+			->assertContains('Certificates')
+			->assertContains('Drivers')
+			->assertContains('Extensions')
+			->assertContains('Log')
+			->assertContains('Nginx')
+			->assertContains('Sites')
+			->assertContains('AcrylicHosts.txt')
+			->assertContains('config.json');
+	}
+
+	/** @test */
+	public function configure_tld()
+	{
+		// $this->container->exec('valet install')->assertSuccessful();
+
+		$this->container->exec('valet tld')
+			->assertSuccessful()
+			->assertContains('test');
+
+		$this->container->exec('valet tld foo')
+			->assertSuccessful()
+			->assertContains('Your Valet TLD has been updated to [foo].');
+
+		$this->container->exec('cat ~/.config/valet/config.json')
+			->assertSuccessful()
+			->decodeOuputJson()
+			->assertFragment(['tld' => 'foo']);
+	}
+
+	/** @test */
+	public function park_directory()
+	{
+		// $this->container->exec('valet install')->assertSuccessful();
+
+		$this->container->exec('mkdir C:/Code')
+			->assertSuccessful();
+
+		$this->container->exec('valet park C:/Code')
+			->assertSuccessful()
+			->assertContains('The [C:/Code] directory has been added to Valet\'s paths.');
+
+		$this->container->exec('cat ~/.config/valet/config.json')
+			->assertSuccessful()
+			->decodeOuputJson()
+			->assertFragment(['paths' => ['C:/Code']]);
+
+		$this->container->exec([
+			'mkdir C:/Code/laravel',
+			"Set-Content -Path 'C:/Code/laravel/index.html' -Value 'hello world'",
+		])
+			->assertSuccessful();
+
+		$this->container->exec('curl.exe --max-time 5 http://laravel.test')
+			->assertSuccessful()
+			->assertContains('hello world');
+	}
+
+	/** @test */
+	public function list_sites_within_parked_paths()
+	{
+		// $this->container->exec('valet install')->assertSuccessful();
+
+		$this->container->exec('mkdir C:/Code/laravel')
+			->assertSuccessful();
+
+		$this->container->exec('valet park C:/Code')
+			->assertSuccessful();
+
+		$this->container->exec('valet parked')
+			->assertSuccessful()
+			->assertContains('| laravel |     | http://laravel.test | C:\Code\laravel |');
+	}
+
+	/** @test */
+	public function forget_parked_path()
+	{
+		// $this->container->exec('valet install')->assertSuccessful();
+
+		$this->container->exec('mkdir C:/Code')
+			->assertSuccessful();
+
+		$this->container->exec('valet park C:/Code')
+			->assertSuccessful();
+
+		$this->container->exec('valet forget C:/Code')
+			->assertSuccessful()
+			->assertContains('The [C:/Code] directory has been removed from Valet\'s paths.');
+
+		$this->container->exec('cat ~/.config/valet/config.json')
+			->assertSuccessful()
+			->decodeOuputJson()
+			->assertFragment(['paths' => []]);
+	}
+
+	/** @test */
+	public function add_symbolic_link()
+	{
+		// $this->container->exec('valet install')->assertSuccessful();
+
+		$this->container->exec('mkdir C:/Code/laravel')
+			->assertSuccessful();
+
+		$this->container->exec('cd C:/Code/laravel; valet link laravel-api')
+			->assertSuccessful()
+			->assertContains('A [laravel-api] symbolic link has been created in [C:/Users/ContainerAdministrator/.config/valet/Sites/laravel-api].');
+
+		$this->container->exec('cat ~/.config/valet/config.json')
+			->assertSuccessful()
+			->decodeOuputJson()
+			->assertFragment(['paths' => ['C:/Users/ContainerAdministrator/.config/valet/Sites']]);
+
+		$this->container->exec('Get-Item -Path ~/.config/valet/Sites/laravel-api')
+			->assertSuccessful()
+			->assertContains('d----l');
+
+		$this->container->exec([
+			'cd C:/Code/laravel',
+			"Set-Content -Path 'C:/Code/laravel/index.html' -Value 'hello world'",
+		])
+			->assertSuccessful();
+
+		$this->container->exec('curl.exe --max-time 5 http://laravel-api.test')
+			->assertSuccessful()
+			->assertContains('hello world');
+	}
+
+	/** @test */
+	public function list_symbolic_links()
+	{
+		// $this->container->exec('valet install')->assertSuccessful();
+
+		$this->container->exec('mkdir C:/Code/laravel')
+			->assertSuccessful();
+
+		$this->container->exec('cd C:/Code/laravel; valet link laravel-api')
+			->assertSuccessful();
+
+		$this->container->exec('valet links')
+			->assertSuccessful()
+			->assertContains('| laravel-api |     | http://laravel-api.test | C:\Code\laravel |');
+	}
+
+	/** @test */
+	public function remove_symbolic_link()
+	{
+		// $this->container->exec('valet install')->assertSuccessful();
+
+		$this->container->exec('mkdir C:/Code/laravel')
+			->assertSuccessful();
+
+		$this->container->exec('cd C:/Code/laravel; valet link laravel-api')
+			->assertSuccessful();
+
+		$this->container->exec('valet unlink laravel-api')
+			->assertSuccessful()
+			->assertContains('The [laravel-api] symbolic link has been removed.');
+
+		$this->container->exec('valet links')
+			->assertSuccessful()
+			->assertNotContains('laravel-api');
+	}
+
+	/** @test */
+	public function secure_domain()
+	{
+		// $this->container->exec('valet install')->assertSuccessful();
+
+		$this->container->exec('valet secure laravel')
+			->assertSuccessful()
+			->assertContains('The [laravel.test] site has been secured with a fresh TLS certificate.');
+
+		$this->container->exec('ls ~/.config/valet/Certificates')
+			->assertContains('laravel.test.crt')
+			->assertContains('laravel.test.csr')
+			->assertContains('laravel.test.key');
+
+		$this->container->exec('Test-Path ~/.config/valet/Nginx/laravel.test.conf')
+			->assertSuccessful()
+			->assertContains('True');
+
+		$this->container->exec([
+			'mkdir C:/Code/laravel', 'cd C:/Code/laravel', 'valet link',
+			"Set-Content -Path 'C:/Code/laravel/index.html' -Value 'hello world'",
+		])
+			->assertSuccessful();
+
+		$this->container->exec('curl.exe --max-time 5 https://laravel.test')
+			->assertSuccessful()
+			->assertContains('hello world');
+
+		$this->container->exec('curl.exe -I --max-time 5 http://laravel.test')
+			->assertSuccessful()
+			->assertContains('HTTP/1.1 302 Moved Temporarily')
+			->assertContains('Location: https://laravel.test/');
+	}
+
+	/** @test */
+	public function unsecure_domain()
+	{
+		// $this->container->exec('valet install')->assertSuccessful();
+
+		$this->container->exec([
+			'mkdir C:/Code/laravel', 'cd C:/Code/laravel', 'valet link',
+			"Set-Content -Path 'C:/Code/laravel/index.html' -Value 'hello world'",
+		])
+			->assertSuccessful();
+
+		$this->container->exec('valet secure laravel')
+			->assertSuccessful();
+
+		$this->container->exec('valet unsecure laravel')
+			->assertSuccessful()
+			->assertContains('The [laravel.test] site will now serve traffic over HTTP.');
+
+		$this->container->exec('Test-Path ~/.config/valet/Nginx/laravel.test.conf')
+			->assertSuccessful()
+			->assertContains('False');
+
+		$this->container->exec('curl.exe --max-time 5 http://laravel.test')
+			->assertSuccessful()
+			->assertContains('hello world');
+
+		$this->container->exec('curl.exe --max-time 5 https://laravel.test')
+			->assertContains('Failed to connect to laravel.test port 443');
+	}
+
+	/** @test */
+	public function unsecure_all_domains()
+	{
+		// $this->container->exec('valet install')->assertSuccessful();
+
+		$this->container->exec([
+			'mkdir C:/Code/laravel1',
+			'mkdir C:/Code/laravel2',
+			'valet park C:/Code',
+			'valet secure laravel1',
+			'valet secure laravel2',
+		])
+			->assertSuccessful();
+
+		$this->container->exec('valet unsecure --all')
+			->assertSuccessful()
+			->assertContains('unsecure --all was successful');
+
+		$this->container->exec('Test-Path ~/.config/valet/Nginx/laravel1.test.conf')
+			->assertSuccessful()
+			->assertContains('False');
+
+		$this->container->exec('Test-Path ~/.config/valet/Nginx/laravel2.test.conf')
+			->assertSuccessful()
+			->assertContains('False');
+	}
+
+	/** @test */
+	public function proxying_services()
+	{
+		// $this->container->exec('valet install')->assertSuccessful();
+
+		$this->container->exec('valet proxy elasticsearch http://127.0.0.1:9200')
+			->assertSuccessful()
+			->assertContains('Valet will now proxy [https://elasticsearch.test] traffic to [http://127.0.0.1:9200].');
+
+		$this->container->exec('Test-Path ~/.config/valet/Nginx/elasticsearch.test.conf')
+			->assertSuccessful()
+			->assertContains('True');
+
+		$this->container->exec('valet proxies')
+			->assertSuccessful()
+			->assertContains('| elasticsearch |  X  | https://elasticsearch.test | http://127.0.0.1:9200 |');
+
+		$this->container->exec('valet unproxy elasticsearch')
+			->assertSuccessful()
+			->assertContains('Valet will no longer proxy [https://elasticsearch.test].');
+
+		$this->container->exec('Test-Path ~/.config/valet/Nginx/elasticsearch.test.conf')
+			->assertSuccessful()
+			->assertContains('False');
+	}
+
+	/** @test */
+	public function determine_valet_driver()
+	{
+		// $this->container->exec('valet install')->assertSuccessful();
+
+		$this->container->exec([
+			'mkdir C:/Code/laravel',
+			"Set-Content -Path 'C:/Code/laravel/index.html' -Value 'hello world'",
+		])
+			->assertSuccessful();
+
+		$this->container->exec('cd C:/Code/laravel; valet which')
+			->assertSuccessful()
+			->assertContains('This site is served by [BasicValetDriver].');
+	}
+
+	/** @test */
+	public function list_paths()
+	{
+		// $this->container->exec('valet install')->assertSuccessful();
+
+		$this->container->exec([
+			'mkdir C:/Code',
+			'valet park C:/Code',
+		])
+			->assertSuccessful();
+
+		$this->container->exec('valet paths')
+			->assertSuccessful()
+			->assertContains('"C:/Code"');
+	}
+
+	/** @test */
+	public function start_daemon_services()
+	{
+		// $this->container->exec('valet install')->assertSuccessful();
+
+		$this->container->exec([
+			'Stop-Service -Name "valet_nginx"',
+			'Stop-Service -Name "valet_phpcgi"',
+			'Stop-Service -Name "AcrylicDNSProxySvc"',
+		])
+			->assertSuccessful();
+
+		$this->container->exec('valet start')
+			->assertSuccessful()
+			->assertContains('Valet services have been started.');
+
+		$this->container->exec('Get-Service -Name "valet_nginx"')
+			->assertSuccessful()
+			->assertContains('Running  valet_nginx');
+
+		$this->container->exec('Get-Service -Name "valet_phpcgi"')
+			->assertSuccessful()
+			->assertContains('Running  valet_phpcgi');
+
+		$this->container->exec('Get-Service -Name "AcrylicDNSProxySvc"')
+			->assertSuccessful()
+			->assertContains('Running  AcrylicDNSProxySvc');
+
+		$this->container->exec('valet start acrylic')
+			->assertSuccessful()
+			->assertContains('Acrylic DNS has been started.');
+
+		$this->container->exec('valet start nginx')
+			->assertSuccessful()
+			->assertContains('Nginx has been started.');
+
+		$this->container->exec('valet start php')
+			->assertSuccessful()
+			->assertContains('PHP has been started.');
+	}
+
+	/** @test */
+	public function stop_daemon_services()
+	{
+		$this->container->exec('valet stop')
+			->assertSuccessful()
+			->assertContains('Valet services have been stopped.');
+
+		$this->container->exec('Get-Service -Name "valet_nginx"')
+			->assertSuccessful()
+			->assertContains('Stopped  valet_nginx');
+
+		$this->container->exec('Get-Service -Name "valet_phpcgi"')
+			->assertSuccessful()
+			->assertContains('Stopped  valet_phpcgi');
+
+		$this->container->exec('Get-Service -Name "AcrylicDNSProxySvc"')
+			->assertSuccessful()
+			->assertContains('Stopped  AcrylicDNSProxySvc');
+
+		$this->container->exec('valet stop acrylic')
+			->assertSuccessful()
+			->assertContains('Acrylic DNS has been stopped.');
+
+		$this->container->exec('valet stop nginx')
+			->assertSuccessful()
+			->assertContains('Nginx has been stopped.');
+
+		$this->container->exec('valet stop php')
+			->assertSuccessful()
+			->assertContains('PHP has been stopped.');
+	}
+
+	/** @test */
+	public function uninstall_valet()
+	{
+		// $this->container->exec('valet install')->assertSuccessful();
+
+		$this->container->exec('valet uninstall --force')
+			->assertSuccessful()
+			->assertContains('Valet has been removed from your system.');
+
+		$this->container->exec('Get-Service -Name "valet_nginx"')
+			->assertContains("Cannot find any service with service name 'valet_nginx'");
+
+		$this->container->exec('Get-Service -Name "valet_phpcgi"')
+			->assertContains("Cannot find any service with service name 'valet_phpcgi'");
+
+		$this->container->exec('Get-Service -Name "AcrylicDNSProxySvc"')
+			->assertContains("Cannot find any service with service name 'AcrylicDNSProxySvc'");
+
+		$this->container->exec('Test-Path ~/.config/valet')
+			->assertContains('True');
+
+		$this->container->exec('valet uninstall --force --purge-config');
+
+		$this->container->exec('Test-Path ~/.config/valet')
+			->assertContains('False');
+	}
 }

--- a/tests/NginxTest.php
+++ b/tests/NginxTest.php
@@ -15,156 +15,156 @@ use Valet\WinSwFactory;
 
 class NginxTest extends TestCase
 {
-    /** @test */
-    public function install_nginx_configuration_places_nginx_base_configuration_in_proper_location()
-    {
-        $this->mock(Configuration::class)
-            ->shouldReceive('get')->once()->with('php_port', 9001)
-            ->andReturn(9001)
-            ->shouldReceive('get')->once()->with('php_xdebug_port', 9002)
-            ->andReturn(9002);
+	/** @test */
+	public function install_nginx_configuration_places_nginx_base_configuration_in_proper_location()
+	{
+		$this->mock(Configuration::class)
+			->shouldReceive('get')->once()->with('php_port', 9001)
+			->andReturn(9001)
+			->shouldReceive('get')->once()->with('php_xdebug_port', 9002)
+			->andReturn(9002);
 
-        $this->partialMock(Filesystem::class)
-            ->shouldReceive('putAsUser')->andReturnUsing(function ($path, $contents) {
-                $this->assertSame(realpath(__DIR__.'/../bin/nginx').'\conf/nginx.conf', $path);
-                $this->assertStringContainsString('include "'.Valet::homePath().'/Nginx/*', $contents);
-            })->once();
+		$this->partialMock(Filesystem::class)
+			->shouldReceive('putAsUser')->andReturnUsing(function ($path, $contents) {
+				$this->assertSame(realpath(__DIR__.'/../bin/nginx').'\conf/nginx.conf', $path);
+				$this->assertStringContainsString('include "'.Valet::homePath().'/Nginx/*', $contents);
+			})->once();
 
-        resolve(Nginx::class)->installConfiguration();
-    }
+		resolve(Nginx::class)->installConfiguration();
+	}
 
-    /** @test */
-    public function install_nginx_directories_creates_location_for_site_specific_configuration()
-    {
-        $this->mock(Filesystem::class)
-            ->shouldReceive('isDir')->with(Valet::homePath('Nginx'))->andReturn(false)
-            ->shouldReceive('mkdirAsUser')->with(Valet::homePath('Nginx'))->once()
-            ->shouldReceive('putAsUser')->with(Valet::homePath('Nginx\.keep'), "\n")->once();
+	/** @test */
+	public function install_nginx_directories_creates_location_for_site_specific_configuration()
+	{
+		$this->mock(Filesystem::class)
+			->shouldReceive('isDir')->with(Valet::homePath('Nginx'))->andReturn(false)
+			->shouldReceive('mkdirAsUser')->with(Valet::homePath('Nginx'))->once()
+			->shouldReceive('putAsUser')->with(Valet::homePath('Nginx\.keep'), "\n")->once();
 
-        $this->mock(Configuration::class)
-            ->shouldReceive('read')
-            ->andReturn(['tld' => 'test']);
+		$this->mock(Configuration::class)
+			->shouldReceive('read')
+			->andReturn(['tld' => 'test']);
 
-        $this->mock(Site::class)
-            ->shouldReceive('resecureForNewTld');
+		$this->mock(Site::class)
+			->shouldReceive('resecureForNewTld');
 
-        resolve(Nginx::class)->installNginxDirectory();
-    }
+		resolve(Nginx::class)->installNginxDirectory();
+	}
 
-    /** @test */
-    public function nginx_directory_is_never_created_if_it_already_exists()
-    {
-        $this->mock(Filesystem::class)
-            ->shouldReceive('isDir')->with(Valet::homePath('Nginx'))->andReturn(true)
-            ->shouldReceive('mkdirAsUser')->never()
-            ->shouldReceive('putAsUser')->with(Valet::homePath('Nginx\.keep'), "\n")->once();
+	/** @test */
+	public function nginx_directory_is_never_created_if_it_already_exists()
+	{
+		$this->mock(Filesystem::class)
+			->shouldReceive('isDir')->with(Valet::homePath('Nginx'))->andReturn(true)
+			->shouldReceive('mkdirAsUser')->never()
+			->shouldReceive('putAsUser')->with(Valet::homePath('Nginx\.keep'), "\n")->once();
 
-        $this->mock(Configuration::class)
-            ->shouldReceive('read')
-            ->andReturn(['tld' => 'test']);
+		$this->mock(Configuration::class)
+			->shouldReceive('read')
+			->andReturn(['tld' => 'test']);
 
-        $this->mock(Site::class)
-            ->shouldReceive('resecureForNewTld');
+		$this->mock(Site::class)
+			->shouldReceive('resecureForNewTld');
 
-        resolve(Nginx::class)->installNginxDirectory();
-    }
+		resolve(Nginx::class)->installNginxDirectory();
+	}
 
-    /** @test */
-    public function install_nginx_directories_rewrites_secure_nginx_files()
-    {
-        $this->mock(Filesystem::class)
-            ->shouldReceive('isDir')->with(Valet::homePath('Nginx'))->andReturn(false)
-            ->shouldReceive('mkdirAsUser')->with(Valet::homePath('Nginx'))->once()
-            ->shouldReceive('putAsUser')->with(Valet::homePath('Nginx\.keep'), "\n")->once();
+	/** @test */
+	public function install_nginx_directories_rewrites_secure_nginx_files()
+	{
+		$this->mock(Filesystem::class)
+			->shouldReceive('isDir')->with(Valet::homePath('Nginx'))->andReturn(false)
+			->shouldReceive('mkdirAsUser')->with(Valet::homePath('Nginx'))->once()
+			->shouldReceive('putAsUser')->with(Valet::homePath('Nginx\.keep'), "\n")->once();
 
-        $this->mock(Configuration::class)
-            ->shouldReceive('read')
-            ->andReturn(['tld' => 'test']);
+		$this->mock(Configuration::class)
+			->shouldReceive('read')
+			->andReturn(['tld' => 'test']);
 
-        $this->mock(Site::class)
-            ->shouldReceive('resecureForNewTld', ['test', 'test']);
+		$this->mock(Site::class)
+			->shouldReceive('resecureForNewTld', ['test', 'test']);
 
-        resolve(Nginx::class)->installNginxDirectory();
-    }
+		resolve(Nginx::class)->installNginxDirectory();
+	}
 
-    /** @test */
-    public function install_nginx_service()
-    {
-        ($winsw = m::mock(WinSW::class))
-            ->shouldReceive('installed')
-                ->once()
-                ->andReturn(false)
-            ->shouldReceive('install')
-                ->once()
-                ->with([
-                    'NGINX_PATH' => realpath(__DIR__.'/../bin/nginx'),
-                ])
-            ->shouldReceive('restart')
-                ->once();
+	/** @test */
+	public function install_nginx_service()
+	{
+		($winsw = m::mock(WinSW::class))
+			->shouldReceive('installed')
+				->once()
+				->andReturn(false)
+			->shouldReceive('install')
+				->once()
+				->with([
+					'NGINX_PATH' => realpath(__DIR__.'/../bin/nginx'),
+				])
+			->shouldReceive('restart')
+				->once();
 
-        $this->mock(WinSwFactory::class)
-            ->shouldReceive('make')
-                ->once()
-                ->with('nginxservice')
-                ->andReturn($winsw);
+		$this->mock(WinSwFactory::class)
+			->shouldReceive('make')
+				->once()
+				->with('nginxservice')
+				->andReturn($winsw);
 
-        resolve(Nginx::class)->installService();
-    }
+		resolve(Nginx::class)->installService();
+	}
 
-    /** @test */
-    public function restart_nginx_service()
-    {
-        $this->mock(CommandLine::class)
-            ->shouldReceive('run')
-            ->once()
-            ->with('cmd "/C taskkill /IM nginx.exe /F"');
+	/** @test */
+	public function restart_nginx_service()
+	{
+		$this->mock(CommandLine::class)
+			->shouldReceive('run')
+			->once()
+			->with('cmd "/C taskkill /IM nginx.exe /F"');
 
-        ($winsw = m::mock(WinSW::class))
-            ->shouldReceive('restart')
-                ->once();
+		($winsw = m::mock(WinSW::class))
+			->shouldReceive('restart')
+				->once();
 
-        $this->mock(WinSwFactory::class)
-            ->shouldReceive('make')
-                ->andReturn($winsw);
+		$this->mock(WinSwFactory::class)
+			->shouldReceive('make')
+				->andReturn($winsw);
 
-        resolve(Nginx::class)->restart();
-    }
+		resolve(Nginx::class)->restart();
+	}
 
-    /** @test */
-    public function stop_nginx_service()
-    {
-        $this->mock(CommandLine::class)
-            ->shouldReceive('run')
-            ->once()
-            ->with('cmd "/C taskkill /IM nginx.exe /F"');
+	/** @test */
+	public function stop_nginx_service()
+	{
+		$this->mock(CommandLine::class)
+			->shouldReceive('run')
+			->once()
+			->with('cmd "/C taskkill /IM nginx.exe /F"');
 
-        ($winsw = m::mock(WinSW::class))
-            ->shouldReceive('stop')
-                ->once();
+		($winsw = m::mock(WinSW::class))
+			->shouldReceive('stop')
+				->once();
 
-        $this->mock(WinSwFactory::class)
-            ->shouldReceive('make')
-                ->andReturn($winsw);
+		$this->mock(WinSwFactory::class)
+			->shouldReceive('make')
+				->andReturn($winsw);
 
-        resolve(Nginx::class)->stop();
-    }
+		resolve(Nginx::class)->stop();
+	}
 
-    /** @test */
-    public function uninstall_nginx_service()
-    {
-        $this->mock(CommandLine::class)
-            ->shouldReceive('run')
-            ->once()
-            ->with('cmd "/C taskkill /IM nginx.exe /F"');
+	/** @test */
+	public function uninstall_nginx_service()
+	{
+		$this->mock(CommandLine::class)
+			->shouldReceive('run')
+			->once()
+			->with('cmd "/C taskkill /IM nginx.exe /F"');
 
-        ($winsw = m::mock(WinSW::class))
-            ->shouldReceive('uninstall')
-                ->once();
+		($winsw = m::mock(WinSW::class))
+			->shouldReceive('uninstall')
+				->once();
 
-        $this->mock(WinSwFactory::class)
-            ->shouldReceive('make')
-                ->andReturn($winsw);
+		$this->mock(WinSwFactory::class)
+			->shouldReceive('make')
+				->andReturn($winsw);
 
-        resolve(Nginx::class)->uninstall();
-    }
+		resolve(Nginx::class)->uninstall();
+	}
 }

--- a/tests/PhpCgiTest.php
+++ b/tests/PhpCgiTest.php
@@ -12,85 +12,85 @@ use Valet\WinSwFactory;
 
 class PhpCgiTest extends TestCase
 {
-    /** @test */
-    public function install_php_cgi_service()
-    {
-        $this->mock(Configuration::class)
-            ->shouldReceive('get')
-            ->with('php_port', 9001)
-            ->andReturn(1234);
+	/** @test */
+	public function install_php_cgi_service()
+	{
+		$this->mock(Configuration::class)
+			->shouldReceive('get')
+			->with('php_port', 9001)
+			->andReturn(1234);
 
-        ($winsw = m::mock(WinSW::class))
-            ->shouldReceive('installed')
-                ->once()
-                ->andReturn(false)
-            ->shouldReceive('install')
-                ->once()
-                ->with([
-                    'PHP_PATH' => $this->findPhpPath(),
-                    'PHP_PORT' => 1234,
-                ])
-            ->shouldReceive('restart')
-                ->once();
+		($winsw = m::mock(WinSW::class))
+			->shouldReceive('installed')
+				->once()
+				->andReturn(false)
+			->shouldReceive('install')
+				->once()
+				->with([
+					'PHP_PATH' => $this->findPhpPath(),
+					'PHP_PORT' => 1234,
+				])
+			->shouldReceive('restart')
+				->once();
 
-        $this->mock(WinSwFactory::class)
-            ->shouldReceive('make')
-                ->once()
-                ->with('phpcgiservice')
-                ->andReturn($winsw);
+		$this->mock(WinSwFactory::class)
+			->shouldReceive('make')
+				->once()
+				->with('phpcgiservice')
+				->andReturn($winsw);
 
-        resolve(PhpCgi::class)->install();
-    }
+		resolve(PhpCgi::class)->install();
+	}
 
-    /** @test */
-    public function uninstall_php_cgi_service()
-    {
-        ($winsw = m::mock(WinSW::class))
-            ->shouldReceive('uninstall')
-            ->once();
+	/** @test */
+	public function uninstall_php_cgi_service()
+	{
+		($winsw = m::mock(WinSW::class))
+			->shouldReceive('uninstall')
+			->once();
 
-        $this->mock(WinSwFactory::class)
-            ->shouldReceive('make')
-            ->andReturn($winsw);
+		$this->mock(WinSwFactory::class)
+			->shouldReceive('make')
+			->andReturn($winsw);
 
-        resolve(PhpCgi::class)->uninstall();
-    }
+		resolve(PhpCgi::class)->uninstall();
+	}
 
-    /** @test */
-    public function restart_php_cgi_service()
-    {
-        ($winsw = m::mock(WinSW::class))
-            ->shouldReceive('restart')
-            ->once();
+	/** @test */
+	public function restart_php_cgi_service()
+	{
+		($winsw = m::mock(WinSW::class))
+			->shouldReceive('restart')
+			->once();
 
-        $this->mock(WinSwFactory::class)
-            ->shouldReceive('make')
-            ->andReturn($winsw);
+		$this->mock(WinSwFactory::class)
+			->shouldReceive('make')
+			->andReturn($winsw);
 
-        resolve(PhpCgi::class)->restart();
-    }
+		resolve(PhpCgi::class)->restart();
+	}
 
-    /** @test */
-    public function stop_php_cgi_service()
-    {
-        ($winsw = m::mock(WinSW::class))
-            ->shouldReceive('stop')
-            ->once();
+	/** @test */
+	public function stop_php_cgi_service()
+	{
+		($winsw = m::mock(WinSW::class))
+			->shouldReceive('stop')
+			->once();
 
-        $this->mock(WinSwFactory::class)
-            ->shouldReceive('make')
-            ->andReturn($winsw);
+		$this->mock(WinSwFactory::class)
+			->shouldReceive('make')
+			->andReturn($winsw);
 
-        resolve(PhpCgi::class)->stop();
-    }
+		resolve(PhpCgi::class)->stop();
+	}
 
-    /**
-     * @return string
-     */
-    protected function findPhpPath(): string
-    {
-        $php = (new PhpExecutableFinder)->find();
+	/**
+	 * @return string
+	 */
+	protected function findPhpPath(): string
+	{
+		$php = (new PhpExecutableFinder)->find();
 
-        return pathinfo(explode("\n", $php)[0], PATHINFO_DIRNAME);
-    }
+		return pathinfo(explode("\n", $php)[0], PATHINFO_DIRNAME);
+	}
 }

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -13,607 +13,607 @@ use function Valet\user;
 
 class SiteTest extends TestCase
 {
-    public function tearDown(): void
-    {
-        parent::tearDown();
-
-        exec('cmd /C rmdir /s /q "'.__DIR__.DIRECTORY_SEPARATOR.'output"');
-        mkdir(__DIR__.'/output');
-        touch(__DIR__.'/output/.gitkeep');
-    }
-
-    public function test_get_certificates_will_return_with_multi_segment_tld()
-    {
-        $files = Mockery::mock(Filesystem::class);
-        $files->shouldReceive('scandir')
-            ->once()
-            ->with($certPath = '/Users/testuser/.config/valet/Certificates')
-            ->andReturn(['helloworld.multi.segment.tld.com.crt']);
-        $files->shouldReceive('ensureDirExists')
-            ->once()
-            ->with('/Users/testuser/.config/valet/Certificates', user());
-        $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('read')
-            ->once()
-            ->andReturn(['tld' => 'multi.segment.tld.com']);
-
-        swap(Filesystem::class, $files);
-        swap(Configuration::class, $config);
-
-        /** @var Site $site */
-        $site = resolve(Site::class);
-        $certs = $site->getCertificates($certPath);
-        $this->assertSame(['helloworld' => 0], $certs->all());
-    }
-
-    public function test_get_sites_will_return_if_secured()
-    {
-        $files = Mockery::mock(Filesystem::class);
-        $dirPath = '/Users/usertest/parkedpath';
-        $files->shouldReceive('scandir')
-            ->once()
-            ->with($dirPath)
-            ->andReturn(['sitetwo', 'sitethree']);
-        $files->shouldReceive('isLink')
-            ->andReturn(false);
-        $files->shouldReceive('realpath')
-            ->twice()
-            ->andReturn($dirPath.'/sitetwo', $dirPath.'/sitethree');
-        $files->shouldReceive('isDir')->andReturn(true);
-        $files->shouldReceive('ensureDirExists')
-            ->once()
-            ->with($dirPath, user());
-
-        $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('read')
-            ->once()
-            ->andReturn(['tld' => 'local']);
-
-        swap(Filesystem::class, $files);
-        swap(Configuration::class, $config);
-
-        /** @var Site $site */
-        $site = resolve(Site::class);
-
-        $certs = Mockery::mock(\Illuminate\Support\Collection::class);
-        $certs->shouldReceive('has')
-            ->twice()
-            ->with(Mockery::on(function ($arg) {
-                return $arg === 'sitetwo' || $arg === 'sitethree';
-            }))
-            ->andReturn(false, true);
-
-        $sites = $site->getSites($dirPath, $certs);
-
-        $this->assertCount(2, $sites);
-        $this->assertSame([
-            'site' => 'sitetwo',
-            'secured' => '',
-            'url' => 'http://sitetwo.local',
-            'path' => $dirPath.'/sitetwo',
-        ], $sites->first());
-        $this->assertSame([
-            'site' => 'sitethree',
-            'secured' => ' X',
-            'url' => 'https://sitethree.local',
-            'path' => $dirPath.'/sitethree',
-        ], $sites->last());
-    }
-
-    public function test_get_sites_will_work_with_non_symlinked_path()
-    {
-        $files = Mockery::mock(Filesystem::class);
-        $dirPath = '/Users/usertest/parkedpath';
-        $files->shouldReceive('scandir')
-            ->once()
-            ->with($dirPath)
-            ->andReturn(['sitetwo']);
-        $files->shouldReceive('isLink')
-            ->once()
-            ->with($dirPath.'/sitetwo')
-            ->andReturn(false);
-        $files->shouldReceive('realpath')
-            ->once()
-            ->with($dirPath.'/sitetwo')
-            ->andReturn($dirPath.'/sitetwo');
-        $files->shouldReceive('isDir')->once()->with($dirPath.'/sitetwo')->andReturn(true);
-        $files->shouldReceive('ensureDirExists')
-            ->once()
-            ->with($dirPath, user());
-
-        $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('read')
-            ->once()
-            ->andReturn(['tld' => 'local']);
-
-        swap(Filesystem::class, $files);
-        swap(Configuration::class, $config);
-
-        /** @var Site $site */
-        $site = resolve(Site::class);
-
-        $sites = $site->getSites($dirPath, collect());
-        $this->assertCount(1, $sites);
-        $this->assertSame([
-            'site' => 'sitetwo',
-            'secured' => '',
-            'url' => 'http://sitetwo.local',
-            'path' => $dirPath.'/sitetwo',
-        ], $sites->first());
-    }
-
-    public function test_get_sites_will_not_return_if_path_is_not_directory()
-    {
-        $files = Mockery::mock(Filesystem::class);
-        $dirPath = '/Users/usertest/parkedpath';
-        $files->shouldReceive('scandir')
-            ->once()
-            ->with($dirPath)
-            ->andReturn(['sitetwo', 'siteone']);
-        $files->shouldReceive('isLink')->andReturn(false);
-        $files->shouldReceive('realpath')->andReturn($dirPath.'/sitetwo', $dirPath.'/siteone');
-        $files->shouldReceive('isDir')->twice()
-            ->andReturn(false, true);
-        $files->shouldReceive('ensureDirExists')
-            ->once()
-            ->with($dirPath, user());
-
-        $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('read')
-            ->once()
-            ->andReturn(['tld' => 'local']);
-
-        swap(Filesystem::class, $files);
-        swap(Configuration::class, $config);
-
-        /** @var Site $site */
-        $site = resolve(Site::class);
-
-        $sites = $site->getSites($dirPath, collect());
-        $this->assertCount(1, $sites);
-        $this->assertSame([
-            'site' => 'siteone',
-            'secured' => '',
-            'url' => 'http://siteone.local',
-            'path' => $dirPath.'/siteone',
-        ], $sites->first());
-    }
-
-    public function test_get_sites_will_work_with_symlinked_path()
-    {
-        $files = Mockery::mock(Filesystem::class);
-        $dirPath = '/Users/usertest/apath';
-        $files->shouldReceive('scandir')
-            ->once()
-            ->with($dirPath)
-            ->andReturn(['siteone']);
-        $files->shouldReceive('isLink')
-            ->once()
-            ->with($dirPath.'/siteone')
-            ->andReturn(true);
-        $files->shouldReceive('readLink')
-            ->once()
-            ->with($dirPath.'/siteone')
-            ->andReturn($linkedPath = '/Users/usertest/linkedpath/siteone');
-        $files->shouldReceive('isDir')->andReturn(true);
-        $files->shouldReceive('ensureDirExists')
-            ->once()
-            ->with($dirPath, user());
-
-        $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('read')
-            ->once()
-            ->andReturn(['tld' => 'local']);
-
-        swap(Filesystem::class, $files);
-        swap(Configuration::class, $config);
-
-        /** @var Site $site */
-        $site = resolve(Site::class);
-
-        $sites = $site->getSites($dirPath, collect());
-        $this->assertCount(1, $sites);
-        $this->assertSame([
-            'site' => 'siteone',
-            'secured' => '',
-            'url' => 'http://siteone.local',
-            'path' => $linkedPath,
-        ], $sites->first());
-    }
-
-    public function test_symlink_creates_symlink_to_given_path()
-    {
-        $files = Mockery::mock(Filesystem::class);
-        $files->shouldReceive('ensureDirExists')->once()->with(VALET_HOME_PATH.'/Sites', user());
-        $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('prependPath')->once()->with(VALET_HOME_PATH.'/Sites');
-        $files->shouldReceive('symlinkAsUser')->once()->with('target', VALET_HOME_PATH.'/Sites/link');
-
-        swap(Filesystem::class, $files);
-        swap(Configuration::class, $config);
-
-        $linkPath = resolve(Site::class)->link('target', 'link');
-        $this->assertSame(VALET_HOME_PATH.'/Sites/link', $linkPath);
-    }
-
-    public function test_unlink_removes_existing_symlink()
-    {
-        file_put_contents(__DIR__.'/output/file.out', 'test');
-        symlink(__DIR__.'/output/file.out', __DIR__.'/output/link');
-        $site = resolve(StubForRemovingLinks::class);
-        $site->unlink('link');
-        $this->assertFileDoesNotExist(__DIR__.'/output/link');
-
-        $site = resolve(StubForRemovingLinks::class);
-        $site->unlink('link');
-        $this->assertFileDoesNotExist(__DIR__.'/output/link');
-    }
-
-    public function test_prune_links_removes_broken_symlinks_in_sites_path()
-    {
-        file_put_contents(__DIR__.'/output/file.out', 'test');
-        symlink(__DIR__.'/output/file.out', __DIR__.'/output/link');
-        unlink(__DIR__.'/output/file.out');
-        $site = resolve(StubForRemovingLinks::class);
-        $site->pruneLinks();
-        $this->assertFileDoesNotExist(__DIR__.'/output/link');
-    }
-
-    public function test_certificates_trim_tld_for_custom_tlds()
-    {
-        $files = Mockery::mock(Filesystem::class);
-        $files->shouldReceive('ensureDirExists')
-            ->once()
-            ->with('fake-cert-path', user());
-        $files->shouldReceive('scandir')->once()->andReturn([
-            'threeletters.dev.crt',
-            'fiveletters.local.crt',
-        ]);
-
-        $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('read')
-            ->once()
-            ->andReturn(['tld' => 'other']);
-
-        swap(Configuration::class, $config);
-        swap(Filesystem::class, $files);
-
-        $site = resolve(Site::class);
-        $certs = $site->getCertificates('fake-cert-path')->flip();
-
-        $this->assertEquals('threeletters', $certs->first());
-        $this->assertEquals('fiveletters', $certs->last());
-    }
-
-    public function test_no_proxies()
-    {
-        $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('read')
-            ->andReturn(['tld' => 'test']);
-
-        swap(Configuration::class, $config);
-
-        /** @var FixturesSiteFake $site */
-        $site = resolve(FixturesSiteFake::class);
-
-        $site->useOutput();
-
-        $this->assertEquals([], $site->proxies()->all());
-    }
-
-    public function test_lists_proxies()
-    {
-        $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('read')
-            ->andReturn(['tld' => 'test']);
-
-        swap(Configuration::class, $config);
-
-        /** @var FixturesSiteFake $site */
-        $site = resolve(FixturesSiteFake::class);
-
-        $site->useFixture('Proxies');
-
-        $this->assertEquals([
-            'some-proxy.com' => [
-                'site' => 'some-proxy.com',
-                'secured' => ' X',
-                'url' => 'https://some-proxy.com.test',
-                'path' => 'https://127.0.0.1:8443',
-            ],
-            'some-other-proxy.com' => [
-                'site' => 'some-other-proxy.com',
-                'secured' => '',
-                'url' => 'http://some-other-proxy.com.test',
-                'path' => 'https://127.0.0.1:8443',
-            ],
-        ], $site->proxies()->all());
-    }
-
-    public function test_add_proxy()
-    {
-        $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('read')
-            ->andReturn(['tld' => 'test']);
-
-        swap(Configuration::class, $config);
-
-        swap(CommandLine::class, resolve(CommandLineFake::class));
-
-        /** @var FixturesSiteFake $site */
-        $site = resolve(FixturesSiteFake::class);
-
-        $site->useOutput();
-
-        $site->assertCertificateNotExists('my-new-proxy.com.test');
-        $site->assertNginxNotExists('my-new-proxy.com.test');
-
-        $site->proxyCreate('my-new-proxy.com', 'https://127.0.0.1:9443');
-
-        $site->assertCertificateExistsWithCounterValue('my-new-proxy.com.test', 0);
-        $site->assertNginxExists('my-new-proxy.com.test');
-
-        $this->assertEquals([
-            'my-new-proxy.com' => [
-                'site' => 'my-new-proxy.com',
-                'secured' => ' X',
-                'url' => 'https://my-new-proxy.com.test',
-                'path' => 'https://127.0.0.1:9443',
-            ],
-        ], $site->proxies()->all());
-    }
-
-    public function test_add_proxy_clears_previous_proxy_certificate()
-    {
-        $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('read')
-            ->andReturn(['tld' => 'test']);
-
-        swap(Configuration::class, $config);
-
-        swap(CommandLine::class, resolve(CommandLineFake::class));
-
-        /** @var FixturesSiteFake $site */
-        $site = resolve(FixturesSiteFake::class);
-
-        $site->useOutput();
-
-        $site->proxyCreate('my-new-proxy.com', 'https://127.0.0.1:7443');
-
-        $site->assertCertificateExistsWithCounterValue('my-new-proxy.com.test', 0);
-
-        $this->assertEquals([
-            'my-new-proxy.com' => [
-                'site' => 'my-new-proxy.com',
-                'secured' => ' X',
-                'url' => 'https://my-new-proxy.com.test',
-                'path' => 'https://127.0.0.1:7443',
-            ],
-        ], $site->proxies()->all());
-
-        // Note: different proxy port
-        $site->proxyCreate('my-new-proxy.com', 'https://127.0.0.1:9443');
-
-        // This shows we created a new certificate.
-        $site->assertCertificateExistsWithCounterValue('my-new-proxy.com.test', 1);
-
-        $this->assertEquals([
-            'my-new-proxy.com' => [
-                'site' => 'my-new-proxy.com',
-                'secured' => ' X',
-                'url' => 'https://my-new-proxy.com.test',
-                'path' => 'https://127.0.0.1:9443',
-            ],
-        ], $site->proxies()->all());
-    }
-
-    public function test_add_proxy_clears_previous_non_proxy_certificate()
-    {
-        $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('read')
-            ->andReturn(['tld' => 'test']);
-
-        swap(Configuration::class, $config);
-
-        swap(CommandLine::class, resolve(CommandLineFake::class));
-
-        /** @var FixturesSiteFake $site */
-        $site = resolve(FixturesSiteFake::class);
-
-        $site->useOutput();
-
-        $site->fakeSecure('my-new-proxy.com.test');
-
-        // For this to test the correct scenario, we need to ensure the
-        // certificate exists but there is not already a proxy Nginx
-        // configuration in place.
-        $site->assertCertificateExistsWithCounterValue('my-new-proxy.com.test', 0);
-        $site->assertNginxNotExists('my-new-proxy.com.test');
-
-        $site->proxyCreate('my-new-proxy.com', 'https://127.0.0.1:9443');
-
-        // This shows we created a new certificate.
-        $site->assertCertificateExistsWithCounterValue('my-new-proxy.com.test', 1);
-
-        $site->assertNginxExists('my-new-proxy.com.test');
-
-        $this->assertEquals([
-            'my-new-proxy.com' => [
-                'site' => 'my-new-proxy.com',
-                'secured' => ' X',
-                'url' => 'https://my-new-proxy.com.test',
-                'path' => 'https://127.0.0.1:9443',
-            ],
-        ], $site->proxies()->all());
-    }
-
-    public function test_remove_proxy()
-    {
-        $config = Mockery::mock(Configuration::class);
-        $config->shouldReceive('read')
-            ->andReturn(['tld' => 'test']);
-
-        swap(Configuration::class, $config);
-
-        swap(CommandLine::class, resolve(CommandLineFake::class));
-
-        /** @var FixturesSiteFake $site */
-        $site = resolve(FixturesSiteFake::class);
-
-        $site->useOutput();
-
-        $site->assertCertificateNotExists('my-new-proxy.com.test');
-        $site->assertNginxNotExists('my-new-proxy.com.test');
-
-        $this->assertEquals([], $site->proxies()->all());
-
-        $site->proxyCreate('my-new-proxy.com', 'https://127.0.0.1:9443');
-
-        $this->assertEquals([
-            'my-new-proxy.com' => [
-                'site' => 'my-new-proxy.com',
-                'secured' => ' X',
-                'url' => 'https://my-new-proxy.com.test',
-                'path' => 'https://127.0.0.1:9443',
-            ],
-        ], $site->proxies()->all());
-
-        $site->assertCertificateExists('my-new-proxy.com.test');
-        $site->assertNginxExists('my-new-proxy.com.test');
-
-        $site->proxyDelete('my-new-proxy.com');
-
-        $site->assertCertificateNotExists('my-new-proxy.com.test');
-        $site->assertNginxNotExists('my-new-proxy.com.test');
-
-        $this->assertEquals([], $site->proxies()->all());
-    }
+	public function tearDown(): void
+	{
+		parent::tearDown();
+
+		exec('cmd /C rmdir /s /q "'.__DIR__.DIRECTORY_SEPARATOR.'output"');
+		mkdir(__DIR__.'/output');
+		touch(__DIR__.'/output/.gitkeep');
+	}
+
+	public function test_get_certificates_will_return_with_multi_segment_tld()
+	{
+		$files = Mockery::mock(Filesystem::class);
+		$files->shouldReceive('scandir')
+			->once()
+			->with($certPath = '/Users/testuser/.config/valet/Certificates')
+			->andReturn(['helloworld.multi.segment.tld.com.crt']);
+		$files->shouldReceive('ensureDirExists')
+			->once()
+			->with('/Users/testuser/.config/valet/Certificates', user());
+		$config = Mockery::mock(Configuration::class);
+		$config->shouldReceive('read')
+			->once()
+			->andReturn(['tld' => 'multi.segment.tld.com']);
+
+		swap(Filesystem::class, $files);
+		swap(Configuration::class, $config);
+
+		/** @var Site $site */
+		$site = resolve(Site::class);
+		$certs = $site->getCertificates($certPath);
+		$this->assertSame(['helloworld' => 0], $certs->all());
+	}
+
+	public function test_get_sites_will_return_if_secured()
+	{
+		$files = Mockery::mock(Filesystem::class);
+		$dirPath = '/Users/usertest/parkedpath';
+		$files->shouldReceive('scandir')
+			->once()
+			->with($dirPath)
+			->andReturn(['sitetwo', 'sitethree']);
+		$files->shouldReceive('isLink')
+			->andReturn(false);
+		$files->shouldReceive('realpath')
+			->twice()
+			->andReturn($dirPath.'/sitetwo', $dirPath.'/sitethree');
+		$files->shouldReceive('isDir')->andReturn(true);
+		$files->shouldReceive('ensureDirExists')
+			->once()
+			->with($dirPath, user());
+
+		$config = Mockery::mock(Configuration::class);
+		$config->shouldReceive('read')
+			->once()
+			->andReturn(['tld' => 'local']);
+
+		swap(Filesystem::class, $files);
+		swap(Configuration::class, $config);
+
+		/** @var Site $site */
+		$site = resolve(Site::class);
+
+		$certs = Mockery::mock(\Illuminate\Support\Collection::class);
+		$certs->shouldReceive('has')
+			->twice()
+			->with(Mockery::on(function ($arg) {
+				return $arg === 'sitetwo' || $arg === 'sitethree';
+			}))
+			->andReturn(false, true);
+
+		$sites = $site->getSites($dirPath, $certs);
+
+		$this->assertCount(2, $sites);
+		$this->assertSame([
+			'site' => 'sitetwo',
+			'secured' => '',
+			'url' => 'http://sitetwo.local',
+			'path' => $dirPath.'/sitetwo',
+		], $sites->first());
+		$this->assertSame([
+			'site' => 'sitethree',
+			'secured' => ' X',
+			'url' => 'https://sitethree.local',
+			'path' => $dirPath.'/sitethree',
+		], $sites->last());
+	}
+
+	public function test_get_sites_will_work_with_non_symlinked_path()
+	{
+		$files = Mockery::mock(Filesystem::class);
+		$dirPath = '/Users/usertest/parkedpath';
+		$files->shouldReceive('scandir')
+			->once()
+			->with($dirPath)
+			->andReturn(['sitetwo']);
+		$files->shouldReceive('isLink')
+			->once()
+			->with($dirPath.'/sitetwo')
+			->andReturn(false);
+		$files->shouldReceive('realpath')
+			->once()
+			->with($dirPath.'/sitetwo')
+			->andReturn($dirPath.'/sitetwo');
+		$files->shouldReceive('isDir')->once()->with($dirPath.'/sitetwo')->andReturn(true);
+		$files->shouldReceive('ensureDirExists')
+			->once()
+			->with($dirPath, user());
+
+		$config = Mockery::mock(Configuration::class);
+		$config->shouldReceive('read')
+			->once()
+			->andReturn(['tld' => 'local']);
+
+		swap(Filesystem::class, $files);
+		swap(Configuration::class, $config);
+
+		/** @var Site $site */
+		$site = resolve(Site::class);
+
+		$sites = $site->getSites($dirPath, collect());
+		$this->assertCount(1, $sites);
+		$this->assertSame([
+			'site' => 'sitetwo',
+			'secured' => '',
+			'url' => 'http://sitetwo.local',
+			'path' => $dirPath.'/sitetwo',
+		], $sites->first());
+	}
+
+	public function test_get_sites_will_not_return_if_path_is_not_directory()
+	{
+		$files = Mockery::mock(Filesystem::class);
+		$dirPath = '/Users/usertest/parkedpath';
+		$files->shouldReceive('scandir')
+			->once()
+			->with($dirPath)
+			->andReturn(['sitetwo', 'siteone']);
+		$files->shouldReceive('isLink')->andReturn(false);
+		$files->shouldReceive('realpath')->andReturn($dirPath.'/sitetwo', $dirPath.'/siteone');
+		$files->shouldReceive('isDir')->twice()
+			->andReturn(false, true);
+		$files->shouldReceive('ensureDirExists')
+			->once()
+			->with($dirPath, user());
+
+		$config = Mockery::mock(Configuration::class);
+		$config->shouldReceive('read')
+			->once()
+			->andReturn(['tld' => 'local']);
+
+		swap(Filesystem::class, $files);
+		swap(Configuration::class, $config);
+
+		/** @var Site $site */
+		$site = resolve(Site::class);
+
+		$sites = $site->getSites($dirPath, collect());
+		$this->assertCount(1, $sites);
+		$this->assertSame([
+			'site' => 'siteone',
+			'secured' => '',
+			'url' => 'http://siteone.local',
+			'path' => $dirPath.'/siteone',
+		], $sites->first());
+	}
+
+	public function test_get_sites_will_work_with_symlinked_path()
+	{
+		$files = Mockery::mock(Filesystem::class);
+		$dirPath = '/Users/usertest/apath';
+		$files->shouldReceive('scandir')
+			->once()
+			->with($dirPath)
+			->andReturn(['siteone']);
+		$files->shouldReceive('isLink')
+			->once()
+			->with($dirPath.'/siteone')
+			->andReturn(true);
+		$files->shouldReceive('readLink')
+			->once()
+			->with($dirPath.'/siteone')
+			->andReturn($linkedPath = '/Users/usertest/linkedpath/siteone');
+		$files->shouldReceive('isDir')->andReturn(true);
+		$files->shouldReceive('ensureDirExists')
+			->once()
+			->with($dirPath, user());
+
+		$config = Mockery::mock(Configuration::class);
+		$config->shouldReceive('read')
+			->once()
+			->andReturn(['tld' => 'local']);
+
+		swap(Filesystem::class, $files);
+		swap(Configuration::class, $config);
+
+		/** @var Site $site */
+		$site = resolve(Site::class);
+
+		$sites = $site->getSites($dirPath, collect());
+		$this->assertCount(1, $sites);
+		$this->assertSame([
+			'site' => 'siteone',
+			'secured' => '',
+			'url' => 'http://siteone.local',
+			'path' => $linkedPath,
+		], $sites->first());
+	}
+
+	public function test_symlink_creates_symlink_to_given_path()
+	{
+		$files = Mockery::mock(Filesystem::class);
+		$files->shouldReceive('ensureDirExists')->once()->with(VALET_HOME_PATH.'/Sites', user());
+		$config = Mockery::mock(Configuration::class);
+		$config->shouldReceive('prependPath')->once()->with(VALET_HOME_PATH.'/Sites');
+		$files->shouldReceive('symlinkAsUser')->once()->with('target', VALET_HOME_PATH.'/Sites/link');
+
+		swap(Filesystem::class, $files);
+		swap(Configuration::class, $config);
+
+		$linkPath = resolve(Site::class)->link('target', 'link');
+		$this->assertSame(VALET_HOME_PATH.'/Sites/link', $linkPath);
+	}
+
+	public function test_unlink_removes_existing_symlink()
+	{
+		file_put_contents(__DIR__.'/output/file.out', 'test');
+		symlink(__DIR__.'/output/file.out', __DIR__.'/output/link');
+		$site = resolve(StubForRemovingLinks::class);
+		$site->unlink('link');
+		$this->assertFileDoesNotExist(__DIR__.'/output/link');
+
+		$site = resolve(StubForRemovingLinks::class);
+		$site->unlink('link');
+		$this->assertFileDoesNotExist(__DIR__.'/output/link');
+	}
+
+	public function test_prune_links_removes_broken_symlinks_in_sites_path()
+	{
+		file_put_contents(__DIR__.'/output/file.out', 'test');
+		symlink(__DIR__.'/output/file.out', __DIR__.'/output/link');
+		unlink(__DIR__.'/output/file.out');
+		$site = resolve(StubForRemovingLinks::class);
+		$site->pruneLinks();
+		$this->assertFileDoesNotExist(__DIR__.'/output/link');
+	}
+
+	public function test_certificates_trim_tld_for_custom_tlds()
+	{
+		$files = Mockery::mock(Filesystem::class);
+		$files->shouldReceive('ensureDirExists')
+			->once()
+			->with('fake-cert-path', user());
+		$files->shouldReceive('scandir')->once()->andReturn([
+			'threeletters.dev.crt',
+			'fiveletters.local.crt',
+		]);
+
+		$config = Mockery::mock(Configuration::class);
+		$config->shouldReceive('read')
+			->once()
+			->andReturn(['tld' => 'other']);
+
+		swap(Configuration::class, $config);
+		swap(Filesystem::class, $files);
+
+		$site = resolve(Site::class);
+		$certs = $site->getCertificates('fake-cert-path')->flip();
+
+		$this->assertEquals('threeletters', $certs->first());
+		$this->assertEquals('fiveletters', $certs->last());
+	}
+
+	public function test_no_proxies()
+	{
+		$config = Mockery::mock(Configuration::class);
+		$config->shouldReceive('read')
+			->andReturn(['tld' => 'test']);
+
+		swap(Configuration::class, $config);
+
+		/** @var FixturesSiteFake $site */
+		$site = resolve(FixturesSiteFake::class);
+
+		$site->useOutput();
+
+		$this->assertEquals([], $site->proxies()->all());
+	}
+
+	public function test_lists_proxies()
+	{
+		$config = Mockery::mock(Configuration::class);
+		$config->shouldReceive('read')
+			->andReturn(['tld' => 'test']);
+
+		swap(Configuration::class, $config);
+
+		/** @var FixturesSiteFake $site */
+		$site = resolve(FixturesSiteFake::class);
+
+		$site->useFixture('Proxies');
+
+		$this->assertEquals([
+			'some-proxy.com' => [
+				'site' => 'some-proxy.com',
+				'secured' => ' X',
+				'url' => 'https://some-proxy.com.test',
+				'path' => 'https://127.0.0.1:8443',
+			],
+			'some-other-proxy.com' => [
+				'site' => 'some-other-proxy.com',
+				'secured' => '',
+				'url' => 'http://some-other-proxy.com.test',
+				'path' => 'https://127.0.0.1:8443',
+			],
+		], $site->proxies()->all());
+	}
+
+	public function test_add_proxy()
+	{
+		$config = Mockery::mock(Configuration::class);
+		$config->shouldReceive('read')
+			->andReturn(['tld' => 'test']);
+
+		swap(Configuration::class, $config);
+
+		swap(CommandLine::class, resolve(CommandLineFake::class));
+
+		/** @var FixturesSiteFake $site */
+		$site = resolve(FixturesSiteFake::class);
+
+		$site->useOutput();
+
+		$site->assertCertificateNotExists('my-new-proxy.com.test');
+		$site->assertNginxNotExists('my-new-proxy.com.test');
+
+		$site->proxyCreate('my-new-proxy.com', 'https://127.0.0.1:9443');
+
+		$site->assertCertificateExistsWithCounterValue('my-new-proxy.com.test', 0);
+		$site->assertNginxExists('my-new-proxy.com.test');
+
+		$this->assertEquals([
+			'my-new-proxy.com' => [
+				'site' => 'my-new-proxy.com',
+				'secured' => ' X',
+				'url' => 'https://my-new-proxy.com.test',
+				'path' => 'https://127.0.0.1:9443',
+			],
+		], $site->proxies()->all());
+	}
+
+	public function test_add_proxy_clears_previous_proxy_certificate()
+	{
+		$config = Mockery::mock(Configuration::class);
+		$config->shouldReceive('read')
+			->andReturn(['tld' => 'test']);
+
+		swap(Configuration::class, $config);
+
+		swap(CommandLine::class, resolve(CommandLineFake::class));
+
+		/** @var FixturesSiteFake $site */
+		$site = resolve(FixturesSiteFake::class);
+
+		$site->useOutput();
+
+		$site->proxyCreate('my-new-proxy.com', 'https://127.0.0.1:7443');
+
+		$site->assertCertificateExistsWithCounterValue('my-new-proxy.com.test', 0);
+
+		$this->assertEquals([
+			'my-new-proxy.com' => [
+				'site' => 'my-new-proxy.com',
+				'secured' => ' X',
+				'url' => 'https://my-new-proxy.com.test',
+				'path' => 'https://127.0.0.1:7443',
+			],
+		], $site->proxies()->all());
+
+		// Note: different proxy port
+		$site->proxyCreate('my-new-proxy.com', 'https://127.0.0.1:9443');
+
+		// This shows we created a new certificate.
+		$site->assertCertificateExistsWithCounterValue('my-new-proxy.com.test', 1);
+
+		$this->assertEquals([
+			'my-new-proxy.com' => [
+				'site' => 'my-new-proxy.com',
+				'secured' => ' X',
+				'url' => 'https://my-new-proxy.com.test',
+				'path' => 'https://127.0.0.1:9443',
+			],
+		], $site->proxies()->all());
+	}
+
+	public function test_add_proxy_clears_previous_non_proxy_certificate()
+	{
+		$config = Mockery::mock(Configuration::class);
+		$config->shouldReceive('read')
+			->andReturn(['tld' => 'test']);
+
+		swap(Configuration::class, $config);
+
+		swap(CommandLine::class, resolve(CommandLineFake::class));
+
+		/** @var FixturesSiteFake $site */
+		$site = resolve(FixturesSiteFake::class);
+
+		$site->useOutput();
+
+		$site->fakeSecure('my-new-proxy.com.test');
+
+		// For this to test the correct scenario, we need to ensure the
+		// certificate exists but there is not already a proxy Nginx
+		// configuration in place.
+		$site->assertCertificateExistsWithCounterValue('my-new-proxy.com.test', 0);
+		$site->assertNginxNotExists('my-new-proxy.com.test');
+
+		$site->proxyCreate('my-new-proxy.com', 'https://127.0.0.1:9443');
+
+		// This shows we created a new certificate.
+		$site->assertCertificateExistsWithCounterValue('my-new-proxy.com.test', 1);
+
+		$site->assertNginxExists('my-new-proxy.com.test');
+
+		$this->assertEquals([
+			'my-new-proxy.com' => [
+				'site' => 'my-new-proxy.com',
+				'secured' => ' X',
+				'url' => 'https://my-new-proxy.com.test',
+				'path' => 'https://127.0.0.1:9443',
+			],
+		], $site->proxies()->all());
+	}
+
+	public function test_remove_proxy()
+	{
+		$config = Mockery::mock(Configuration::class);
+		$config->shouldReceive('read')
+			->andReturn(['tld' => 'test']);
+
+		swap(Configuration::class, $config);
+
+		swap(CommandLine::class, resolve(CommandLineFake::class));
+
+		/** @var FixturesSiteFake $site */
+		$site = resolve(FixturesSiteFake::class);
+
+		$site->useOutput();
+
+		$site->assertCertificateNotExists('my-new-proxy.com.test');
+		$site->assertNginxNotExists('my-new-proxy.com.test');
+
+		$this->assertEquals([], $site->proxies()->all());
+
+		$site->proxyCreate('my-new-proxy.com', 'https://127.0.0.1:9443');
+
+		$this->assertEquals([
+			'my-new-proxy.com' => [
+				'site' => 'my-new-proxy.com',
+				'secured' => ' X',
+				'url' => 'https://my-new-proxy.com.test',
+				'path' => 'https://127.0.0.1:9443',
+			],
+		], $site->proxies()->all());
+
+		$site->assertCertificateExists('my-new-proxy.com.test');
+		$site->assertNginxExists('my-new-proxy.com.test');
+
+		$site->proxyDelete('my-new-proxy.com');
+
+		$site->assertCertificateNotExists('my-new-proxy.com.test');
+		$site->assertNginxNotExists('my-new-proxy.com.test');
+
+		$this->assertEquals([], $site->proxies()->all());
+	}
 }
 
 class CommandLineFake extends CommandLine
 {
-    public function runCommand($command, callable $onError = null)
-    {
-        // noop
-        //
-        // This let's us pretend like every command executes correctly
-        // so we can (elsewhere) ensure the things we meant to do
-        // (like "create a certificate") look like they
-        // happened without actually running any
-        // commands for real.
-    }
+	public function runCommand($command, callable $onError = null)
+	{
+		// noop
+		//
+		// This let's us pretend like every command executes correctly
+		// so we can (elsewhere) ensure the things we meant to do
+		// (like "create a certificate") look like they
+		// happened without actually running any
+		// commands for real.
+	}
 }
 
 class FixturesSiteFake extends Site
 {
-    private $valetHomePath;
-    private $crtCounter = 0;
+	private $valetHomePath;
+	private $crtCounter = 0;
 
-    public function valetHomePath()
-    {
-        if (! isset($this->valetHomePath)) {
-            throw new \RuntimeException(static::class.' needs to be configured using useFixtures or useOutput');
-        }
+	public function valetHomePath()
+	{
+		if (! isset($this->valetHomePath)) {
+			throw new \RuntimeException(static::class.' needs to be configured using useFixtures or useOutput');
+		}
 
-        return $this->valetHomePath;
-    }
+		return $this->valetHomePath;
+	}
 
-    /**
-     * Use a named fixture (tests/fixtures/[Name]) for this
-     * instance of the Site.
-     */
-    public function useFixture($fixtureName)
-    {
-        $this->valetHomePath = __DIR__.'/fixtures/'.$fixtureName;
-    }
+	/**
+	 * Use a named fixture (tests/fixtures/[Name]) for this
+	 * instance of the Site.
+	 */
+	public function useFixture($fixtureName)
+	{
+		$this->valetHomePath = __DIR__.'/fixtures/'.$fixtureName;
+	}
 
-    /**
-     * Use the output directory (tests/output) for this instance
-     * of the Site.
-     */
-    public function useOutput()
-    {
-        $this->valetHomePath = __DIR__.'/output';
-    }
+	/**
+	 * Use the output directory (tests/output) for this instance
+	 * of the Site.
+	 */
+	public function useOutput()
+	{
+		$this->valetHomePath = __DIR__.'/output';
+	}
 
-    public function createCa()
-    {
-        // noop
-        //
-        // Most of our certificate testing is primitive and not super
-        // "correct" so we're not going to even bother creating the
-        // CA for our faked Site.
-    }
+	public function createCa()
+	{
+		// noop
+		//
+		// Most of our certificate testing is primitive and not super
+		// "correct" so we're not going to even bother creating the
+		// CA for our faked Site.
+	}
 
-    public function createCertificate($urlWithTld)
-    {
-        // We're not actually going to generate a real certificate
-        // here. We are going to do something basic to include
-        // the URL and a counter so we can see if this
-        // method was called when we expect and also
-        // ensure a file is written out in the
-        // expected and correct place.
+	public function createCertificate($urlWithTld)
+	{
+		// We're not actually going to generate a real certificate
+		// here. We are going to do something basic to include
+		// the URL and a counter so we can see if this
+		// method was called when we expect and also
+		// ensure a file is written out in the
+		// expected and correct place.
 
-        $crtPath = $this->certificatesPath($urlWithTld, 'crt');
-        $keyPath = $this->certificatesPath($urlWithTld, 'key');
+		$crtPath = $this->certificatesPath($urlWithTld, 'crt');
+		$keyPath = $this->certificatesPath($urlWithTld, 'key');
 
-        $counter = $this->crtCounter++;
+		$counter = $this->crtCounter++;
 
-        file_put_contents($crtPath, 'crt:'.$urlWithTld.':'.$counter);
-        file_put_contents($keyPath, 'key:'.$urlWithTld.':'.$counter);
-    }
+		file_put_contents($crtPath, 'crt:'.$urlWithTld.':'.$counter);
+		file_put_contents($keyPath, 'key:'.$urlWithTld.':'.$counter);
+	}
 
-    public function fakeSecure($urlWithTld)
-    {
-        // This method is just used to ensure we all understand that we are
-        // forcing a fake creation of a URL (including .tld) and passes
-        // through to createCertificate() directly.
-        $this->files->ensureDirExists($this->certificatesPath(), user());
-        $this->createCertificate($urlWithTld);
-    }
+	public function fakeSecure($urlWithTld)
+	{
+		// This method is just used to ensure we all understand that we are
+		// forcing a fake creation of a URL (including .tld) and passes
+		// through to createCertificate() directly.
+		$this->files->ensureDirExists($this->certificatesPath(), user());
+		$this->createCertificate($urlWithTld);
+	}
 
-    public function assertNginxExists($urlWithTld)
-    {
-        SiteTest::assertFileExists($this->nginxPath($urlWithTld));
-    }
+	public function assertNginxExists($urlWithTld)
+	{
+		SiteTest::assertFileExists($this->nginxPath($urlWithTld));
+	}
 
-    public function assertNginxNotExists($urlWithTld)
-    {
-        SiteTest::assertFileDoesNotExist($this->nginxPath($urlWithTld));
-    }
+	public function assertNginxNotExists($urlWithTld)
+	{
+		SiteTest::assertFileDoesNotExist($this->nginxPath($urlWithTld));
+	}
 
-    public function assertCertificateExists($urlWithTld)
-    {
-        SiteTest::assertFileExists($this->certificatesPath($urlWithTld, 'crt'));
-        SiteTest::assertFileExists($this->certificatesPath($urlWithTld, 'key'));
-    }
+	public function assertCertificateExists($urlWithTld)
+	{
+		SiteTest::assertFileExists($this->certificatesPath($urlWithTld, 'crt'));
+		SiteTest::assertFileExists($this->certificatesPath($urlWithTld, 'key'));
+	}
 
-    public function assertCertificateNotExists($urlWithTld)
-    {
-        SiteTest::assertFileDoesNotExist($this->certificatesPath($urlWithTld, 'crt'));
-        SiteTest::assertFileDoesNotExist($this->certificatesPath($urlWithTld, 'key'));
-    }
+	public function assertCertificateNotExists($urlWithTld)
+	{
+		SiteTest::assertFileDoesNotExist($this->certificatesPath($urlWithTld, 'crt'));
+		SiteTest::assertFileDoesNotExist($this->certificatesPath($urlWithTld, 'key'));
+	}
 
-    public function assertCertificateExistsWithCounterValue($urlWithTld, $counter)
-    {
-        // Simple test to assert the certificate for the specified
-        // URL (including .tld) exists and has the expected
-        // fake contents.
+	public function assertCertificateExistsWithCounterValue($urlWithTld, $counter)
+	{
+		// Simple test to assert the certificate for the specified
+		// URL (including .tld) exists and has the expected
+		// fake contents.
 
-        $this->assertCertificateExists($urlWithTld);
+		$this->assertCertificateExists($urlWithTld);
 
-        $crtPath = $this->certificatesPath($urlWithTld, 'crt');
-        $keyPath = $this->certificatesPath($urlWithTld, 'key');
+		$crtPath = $this->certificatesPath($urlWithTld, 'crt');
+		$keyPath = $this->certificatesPath($urlWithTld, 'key');
 
-        SiteTest::assertEquals('crt:'.$urlWithTld.':'.$counter, file_get_contents($crtPath));
-        SiteTest::assertEquals('key:'.$urlWithTld.':'.$counter, file_get_contents($keyPath));
-    }
+		SiteTest::assertEquals('crt:'.$urlWithTld.':'.$counter, file_get_contents($crtPath));
+		SiteTest::assertEquals('key:'.$urlWithTld.':'.$counter, file_get_contents($keyPath));
+	}
 }
 
 class StubForRemovingLinks extends Site
 {
-    public function sitesPath($additionalPath = null)
-    {
-        return __DIR__.'/output'.($additionalPath ? '/'.$additionalPath : '');
-    }
+	public function sitesPath($additionalPath = null)
+	{
+		return __DIR__.'/output'.($additionalPath ? '/'.$additionalPath : '');
+	}
 }

--- a/tests/Support/ConsoleOutputContainsConstraint.php
+++ b/tests/Support/ConsoleOutputContainsConstraint.php
@@ -6,75 +6,75 @@ use PHPUnit\Framework\Constraint\Constraint;
 
 class ConsoleOutputContainsConstraint extends Constraint
 {
-    /**
-     * @var string
-     */
-    private $string;
+	/**
+	 * @var string
+	 */
+	private $string;
 
-    /**
-     * @var bool
-     */
-    private $ignoreCase;
+	/**
+	 * @var bool
+	 */
+	private $ignoreCase;
 
-    public function __construct(string $string, bool $ignoreCase = false)
-    {
-        $this->string = $string;
-        $this->ignoreCase = $ignoreCase;
-    }
+	public function __construct(string $string, bool $ignoreCase = false)
+	{
+		$this->string = $string;
+		$this->ignoreCase = $ignoreCase;
+	}
 
-    /**
-     * Returns a string representation of the constraint.
-     */
-    public function toString(): string
-    {
-        if ($this->ignoreCase) {
-            $string = mb_strtolower($this->string, 'UTF-8');
-        } else {
-            $string = $this->string;
-        }
+	/**
+	 * Returns a string representation of the constraint.
+	 */
+	public function toString(): string
+	{
+		if ($this->ignoreCase) {
+			$string = mb_strtolower($this->string, 'UTF-8');
+		} else {
+			$string = $this->string;
+		}
 
-        return sprintf(
-            'contains "%s"',
-            $string
-        );
-    }
+		return sprintf(
+			'contains "%s"',
+			$string
+		);
+	}
 
-    /**
-     * Evaluates the constraint for parameter $other. Returns true if the
-     * constraint is met, false otherwise.
-     *
-     * @param  mixed  $other  value or object to evaluate
-     */
-    protected function matches($other): bool
-    {
-        if ('' === $this->string) {
-            return true;
-        }
+	/**
+	 * Evaluates the constraint for parameter $other. Returns true if the
+	 * constraint is met, false otherwise.
+	 *
+	 * @param  mixed  $other  value or object to evaluate
+	 */
+	protected function matches($other): bool
+	{
+		if ('' === $this->string) {
+			return true;
+		}
 
-        if ($this->ignoreCase) {
-            /*
-             * We must use the multi byte safe version so we can accurately compare non latin upper characters with
-             * their lowercase equivalents.
-             */
-            return mb_stripos($other, $this->string, 0, 'UTF-8') !== false;
-        }
+		if ($this->ignoreCase) {
+			/*
+			 * We must use the multi byte safe version so we can accurately compare non latin upper characters with
+			 * their lowercase equivalents.
+			 */
+			return mb_stripos($other, $this->string, 0, 'UTF-8') !== false;
+		}
 
-        /*
-         * Use the non multi byte safe functions to see if the string is contained in $other.
-         *
-         * This function is very fast and we don't care about the character position in the string.
-         *
-         * Additionally, we want this method to be binary safe so we can check if some binary data is in other binary
-         * data.
-         */
-        return strpos($other, $this->string) !== false;
-    }
+		/*
+		 * Use the non multi byte safe functions to see if the string is contained in $other.
+		 *
+		 * This function is very fast and we don't care about the character position in the string.
+		 *
+		 * Additionally, we want this method to be binary safe so we can check if some binary data is in other binary
+		 * data.
+		 */
+		return strpos($other, $this->string) !== false;
+	}
 
-    /**
-     * @inheritDoc
-     */
-    protected function failureDescription($other): string
-    {
-        return "Output: \n--- begin output ---\n".$other."\n--- end output ---\n".$this->toString();
-    }
+	/**
+	 * @inheritDoc
+	 */
+	protected function failureDescription($other): string
+	{
+		return "Output: \n--- begin output ---\n".$other."\n--- end output ---\n".$this->toString();
+	}
 }

--- a/tests/Support/DockerContainer.php
+++ b/tests/Support/DockerContainer.php
@@ -6,33 +6,33 @@ use Spatie\Docker\DockerContainer as SpatieDockerContainer;
 
 class DockerContainer extends SpatieDockerContainer
 {
-    public string $command = '';
+	public string $command = '';
 
-    public function command(string $command): self
-    {
-        $this->command = $command;
+	public function command(string $command): self
+	{
+		$this->command = $command;
 
-        return $this;
-    }
+		return $this;
+	}
 
-    public function getStartCommand(): string
-    {
-        return parent::getStartCommand().' '.$this->command;
-    }
+	public function getStartCommand(): string
+	{
+		return parent::getStartCommand().' '.$this->command;
+	}
 
-    public static function create(...$args): self
-    {
-        return new static(...$args);
-    }
+	public static function create(...$args): self
+	{
+		return new static(...$args);
+	}
 
-    public function start(): DockerContainerInstance
-    {
-        $containerInstance = parent::start();
+	public function start(): DockerContainerInstance
+	{
+		$containerInstance = parent::start();
 
-        return new DockerContainerInstance(
-            $this,
-            $containerInstance->getDockerIdentifier(),
-            $this->name,
-        );
-    }
+		return new DockerContainerInstance(
+			$this,
+			$containerInstance->getDockerIdentifier(),
+			$this->name,
+		);
+	}
 }

--- a/tests/Support/DockerContainerInstance.php
+++ b/tests/Support/DockerContainerInstance.php
@@ -7,22 +7,22 @@ use Symfony\Component\Process\Process;
 
 class DockerContainerInstance extends SpatieDockerContainerInstance
 {
-    /**
-     * @param  string|array  $command
-     * @return \Tests\Support\TestProcess
-     */
-    public function exec($command): TestProcess
-    {
-        if (is_array($command)) {
-            $command = implode(';', $command);
-        }
+	/**
+	 * @param  string|array  $command
+	 * @return \Tests\Support\TestProcess
+	 */
+	public function exec($command): TestProcess
+	{
+		if (is_array($command)) {
+			$command = implode(';', $command);
+		}
 
-        $fullCommand = "docker exec --interactive {$this->getShortDockerIdentifier()} powershell -Command \"{$command}\"";
+		$fullCommand = "docker exec --interactive {$this->getShortDockerIdentifier()} powershell -Command \"{$command}\"";
 
-        $process = Process::fromShellCommandline($fullCommand);
+		$process = Process::fromShellCommandline($fullCommand);
 
-        $process->setTimeout(30)->run();
+		$process->setTimeout(30)->run();
 
-        return new TestProcess($process);
-    }
+		return new TestProcess($process);
+	}
 }

--- a/tests/Support/FakeProcessOutput.php
+++ b/tests/Support/FakeProcessOutput.php
@@ -7,55 +7,55 @@ use Valet\ProcessOutput;
 
 class FakeProcessOutput extends ProcessOutput
 {
-    /**
-     * @var string
-     */
-    public $output = '';
+	/**
+	 * @var string
+	 */
+	public $output = '';
 
-    /**
-     * @var bool
-     */
-    public $successfull = true;
+	/**
+	 * @var bool
+	 */
+	public $successfull = true;
 
-    /**
-     * @param  string  $output
-     * @return self
-     */
-    public static function successfull(string $output = ''): self
-    {
-        $process = new FakeProcessOutput(new Process([]));
-        $process->output = $output;
-        $process->successfull = true;
+	/**
+	 * @param  string  $output
+	 * @return self
+	 */
+	public static function successfull(string $output = ''): self
+	{
+		$process = new FakeProcessOutput(new Process([]));
+		$process->output = $output;
+		$process->successfull = true;
 
-        return $process;
-    }
+		return $process;
+	}
 
-    /**
-     * @param  string  $output
-     * @return self
-     */
-    public static function unsuccessfull(string $output = ''): self
-    {
-        $process = new FakeProcessOutput(new Process([]));
-        $process->output = $output;
-        $process->successfull = false;
+	/**
+	 * @param  string  $output
+	 * @return self
+	 */
+	public static function unsuccessfull(string $output = ''): self
+	{
+		$process = new FakeProcessOutput(new Process([]));
+		$process->output = $output;
+		$process->successfull = false;
 
-        return $process;
-    }
+		return $process;
+	}
 
-    /**
-     * @return string
-     */
-    public function getOutput(): string
-    {
-        return $this->output;
-    }
+	/**
+	 * @return string
+	 */
+	public function getOutput(): string
+	{
+		return $this->output;
+	}
 
-    /**
-     * @return bool
-     */
-    public function isSuccessful(): bool
-    {
-        return $this->successfull;
-    }
+	/**
+	 * @return bool
+	 */
+	public function isSuccessful(): bool
+	{
+		return $this->successfull;
+	}
 }

--- a/tests/Support/TestProcess.php
+++ b/tests/Support/TestProcess.php
@@ -9,134 +9,134 @@ use Symfony\Component\Process\Process;
 
 class TestProcess
 {
-    /**
-     * The process to delegate to.
-     *
-     * @var \Symfony\Component\Process\Process
-     */
-    public $baseProcess;
+	/**
+	 * The process to delegate to.
+	 *
+	 * @var \Symfony\Component\Process\Process
+	 */
+	public $baseProcess;
 
-    /**
-     * Create a new test process instance.
-     *
-     * @param  \Symfony\Component\Process\Process  $process
-     * @return void
-     */
-    public function __construct(Process $process)
-    {
-        $this->baseProcess = $process;
-    }
+	/**
+	 * Create a new test process instance.
+	 *
+	 * @param  \Symfony\Component\Process\Process  $process
+	 * @return void
+	 */
+	public function __construct(Process $process)
+	{
+		$this->baseProcess = $process;
+	}
 
-    /**
-     * @return string
-     */
-    public function getOutput(): string
-    {
-        if ($this->baseProcess->isSuccessful()) {
-            return $this->baseProcess->getOutput();
-        }
+	/**
+	 * @return string
+	 */
+	public function getOutput(): string
+	{
+		if ($this->baseProcess->isSuccessful()) {
+			return $this->baseProcess->getOutput();
+		}
 
-        return $this->baseProcess->getErrorOutput();
-    }
+		return $this->baseProcess->getErrorOutput();
+	}
 
-    /**
-     * Validate and return the decoded output JSON.
-     *
-     * @param  string|null  $key
-     * @return mixed
-     */
-    public function json(string $key = null)
-    {
-        return $this->decodeOuputJson()->json($key);
-    }
+	/**
+	 * Validate and return the decoded output JSON.
+	 *
+	 * @param  string|null  $key
+	 * @return mixed
+	 */
+	public function json(string $key = null)
+	{
+		return $this->decodeOuputJson()->json($key);
+	}
 
-    /**
-     * Validate and return the decoded output JSON.
-     *
-     * @return \Illuminate\Testing\AssertableJsonString
-     *
-     * @throws \Throwable
-     */
-    public function decodeOuputJson()
-    {
-        $testJson = new AssertableJsonString($this->getOutput());
+	/**
+	 * Validate and return the decoded output JSON.
+	 *
+	 * @return \Illuminate\Testing\AssertableJsonString
+	 *
+	 * @throws \Throwable
+	 */
+	public function decodeOuputJson()
+	{
+		$testJson = new AssertableJsonString($this->getOutput());
 
-        $decodedResponse = $testJson->json();
+		$decodedResponse = $testJson->json();
 
-        if (is_null($decodedResponse) || $decodedResponse === false) {
-            if ($this->exception) {
-                throw $this->exception;
-            } else {
-                PHPUnit::fail('Invalid JSON was returned from the output.');
-            }
-        }
+		if (is_null($decodedResponse) || $decodedResponse === false) {
+			if ($this->exception) {
+				throw $this->exception;
+			} else {
+				PHPUnit::fail('Invalid JSON was returned from the output.');
+			}
+		}
 
-        return $testJson;
-    }
+		return $testJson;
+	}
 
-    /**
-     * Dump the output.
-     *
-     * @return self
-     */
-    public function dump()
-    {
-        fwrite(STDERR, print_r($this->getOutput(), true));
+	/**
+	 * Dump the output.
+	 *
+	 * @return self
+	 */
+	public function dump()
+	{
+		fwrite(STDERR, print_r($this->getOutput(), true));
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Assert that the process has a successful exit code.
-     *
-     * @return self
-     */
-    public function assertSuccessful(): self
-    {
-        PHPUnit::assertTrue(
-            $this->baseProcess->isSuccessful(),
-            'Exit code ['.$this->baseProcess->getExitCode().'] is not a successful exit code. Error Output:'.
-            PHP_EOL.$this->baseProcess->getErrorOutput()
-        );
+	/**
+	 * Assert that the process has a successful exit code.
+	 *
+	 * @return self
+	 */
+	public function assertSuccessful(): self
+	{
+		PHPUnit::assertTrue(
+			$this->baseProcess->isSuccessful(),
+			'Exit code ['.$this->baseProcess->getExitCode().'] is not a successful exit code. Error Output:'.
+			PHP_EOL.$this->baseProcess->getErrorOutput()
+		);
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Assert that the output contains the given string.
-     *
-     * @param  string  $needle
-     * @return self
-     */
-    public function assertContains(string $needle): self
-    {
-        PHPUnit::assertThat($this->getOutput(), new ConsoleOutputContainsConstraint($needle));
+	/**
+	 * Assert that the output contains the given string.
+	 *
+	 * @param  string  $needle
+	 * @return self
+	 */
+	public function assertContains(string $needle): self
+	{
+		PHPUnit::assertThat($this->getOutput(), new ConsoleOutputContainsConstraint($needle));
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Assert that the output does not contain the given string.
-     *
-     * @param  string  $needle
-     * @return self
-     */
-    public function assertNotContains(string $needle)
-    {
-        PHPUnit::assertThat($this->getOutput(), new LogicalNot(new ConsoleOutputContainsConstraint($needle)));
+	/**
+	 * Assert that the output does not contain the given string.
+	 *
+	 * @param  string  $needle
+	 * @return self
+	 */
+	public function assertNotContains(string $needle)
+	{
+		PHPUnit::assertThat($this->getOutput(), new LogicalNot(new ConsoleOutputContainsConstraint($needle)));
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Handle dynamic calls into macros or pass missing methods to the base process.
-     *
-     * @param  string  $method
-     * @param  array  $args
-     * @return mixed
-     */
-    public function __call($method, $args)
-    {
-        return $this->baseProcess->{$method}(...$args);
-    }
+	/**
+	 * Handle dynamic calls into macros or pass missing methods to the base process.
+	 *
+	 * @param  string  $method
+	 * @param  array  $args
+	 * @return mixed
+	 */
+	public function __call($method, $args)
+	{
+		return $this->baseProcess->{$method}(...$args);
+	}
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,62 +9,62 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    /**
-     * @return void
-     */
-    public function tearDown(): void
-    {
-        Mockery::close();
-        Container::setInstance(null);
-    }
+	/**
+	 * @return void
+	 */
+	public function tearDown(): void
+	{
+		Mockery::close();
+		Container::setInstance(null);
+	}
 
-    /**
-     * Register an instance of an object in the container.
-     *
-     * @param  string  $abstract
-     * @param  object  $instance
-     * @return object
-     */
-    protected function instance($abstract, $instance)
-    {
-        Container::getInstance()->instance($abstract, $instance);
+	/**
+	 * Register an instance of an object in the container.
+	 *
+	 * @param  string  $abstract
+	 * @param  object  $instance
+	 * @return object
+	 */
+	protected function instance($abstract, $instance)
+	{
+		Container::getInstance()->instance($abstract, $instance);
 
-        return $instance;
-    }
+		return $instance;
+	}
 
-    /**
-     * Mock an instance of an object in the container.
-     *
-     * @param  string  $abstract
-     * @param  \Closure|null  $mock
-     * @return \Mockery\MockInterface
-     */
-    protected function mock($abstract, Closure $mock = null)
-    {
-        return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args())));
-    }
+	/**
+	 * Mock an instance of an object in the container.
+	 *
+	 * @param  string  $abstract
+	 * @param  \Closure|null  $mock
+	 * @return \Mockery\MockInterface
+	 */
+	protected function mock($abstract, Closure $mock = null)
+	{
+		return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args())));
+	}
 
-    /**
-     * Mock a partial instance of an object in the container.
-     *
-     * @param  string  $abstract
-     * @param  \Closure|null  $mock
-     * @return \Mockery\MockInterface
-     */
-    protected function partialMock($abstract, Closure $mock = null)
-    {
-        return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args()))->makePartial());
-    }
+	/**
+	 * Mock a partial instance of an object in the container.
+	 *
+	 * @param  string  $abstract
+	 * @param  \Closure|null  $mock
+	 * @return \Mockery\MockInterface
+	 */
+	protected function partialMock($abstract, Closure $mock = null)
+	{
+		return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args()))->makePartial());
+	}
 
-    /**
-     * Spy an instance of an object in the container.
-     *
-     * @param  string  $abstract
-     * @param  \Closure|null  $mock
-     * @return \Mockery\MockInterface
-     */
-    protected function spy($abstract, Closure $mock = null)
-    {
-        return $this->instance($abstract, Mockery::spy(...array_filter(func_get_args())));
-    }
+	/**
+	 * Spy an instance of an object in the container.
+	 *
+	 * @param  string  $abstract
+	 * @param  \Closure|null  $mock
+	 * @return \Mockery\MockInterface
+	 */
+	protected function spy($abstract, Closure $mock = null)
+	{
+		return $this->instance($abstract, Mockery::spy(...array_filter(func_get_args())));
+	}
 }

--- a/tests/ValetTest.php
+++ b/tests/ValetTest.php
@@ -8,52 +8,52 @@ use Valet\Valet;
 
 class ValetTest extends TestCase
 {
-    /** @test */
-    public function list_valet_services()
-    {
-        $this->mock(CommandLine::class)
-            ->shouldReceive('run')
-                ->once()
-                ->with('powershell -command "Get-Service -Name AcrylicDNSProxySvc"')
-                ->andReturn('Running  AcrylicDNSProxySvc        AcrylicDNSProxySvc')
-            ->shouldReceive('run')
-                ->once()
-                ->with('powershell -command "Get-Service -Name valet_nginx"')
-                ->andReturn('Running  valet_nginx        valet_nginx')
-            ->shouldReceive('run')
-                ->once()
-                ->with('powershell -command "Get-Service -Name valet_phpcgi"')
-                ->andReturn('Running  valet_phpcgi        valet_phpcgi')
-            ->shouldReceive('run')
-                ->once()
-                ->with('powershell -command "Get-Service -Name valet_phpcgi_xdebug"')
-                ->andReturn('Running  valet_phpcgi_xdebug        valet_phpcgi_xdebug');
+	/** @test */
+	public function list_valet_services()
+	{
+		$this->mock(CommandLine::class)
+			->shouldReceive('run')
+				->once()
+				->with('powershell -command "Get-Service -Name AcrylicDNSProxySvc"')
+				->andReturn('Running  AcrylicDNSProxySvc        AcrylicDNSProxySvc')
+			->shouldReceive('run')
+				->once()
+				->with('powershell -command "Get-Service -Name valet_nginx"')
+				->andReturn('Running  valet_nginx        valet_nginx')
+			->shouldReceive('run')
+				->once()
+				->with('powershell -command "Get-Service -Name valet_phpcgi"')
+				->andReturn('Running  valet_phpcgi        valet_phpcgi')
+			->shouldReceive('run')
+				->once()
+				->with('powershell -command "Get-Service -Name valet_phpcgi_xdebug"')
+				->andReturn('Running  valet_phpcgi_xdebug        valet_phpcgi_xdebug');
 
-        $services = resolve(Valet::class)->services();
+		$services = resolve(Valet::class)->services();
 
-        $this->assertCount(4, $services);
+		$this->assertCount(4, $services);
 
-        $this->assertSame([
-            [
-                'service' => 'acrylic',
-                'winname' => 'AcrylicDNSProxySvc',
-                'status' => '<fg=green>running</>',
-            ],
-            [
-                'service' => 'nginx',
-                'winname' => 'valet_nginx',
-                'status' => '<fg=green>running</>',
-            ],
-            [
-                'service' => 'php',
-                'winname' => 'valet_phpcgi',
-                'status' => '<fg=green>running</>',
-            ],
-            [
-                'service' => 'php-xdebug',
-                'winname' => 'valet_phpcgi_xdebug',
-                'status' => '<fg=green>running</>',
-            ],
-        ], $services);
-    }
+		$this->assertSame([
+			[
+				'service' => 'acrylic',
+				'winname' => 'AcrylicDNSProxySvc',
+				'status' => '<fg=green>running</>',
+			],
+			[
+				'service' => 'nginx',
+				'winname' => 'valet_nginx',
+				'status' => '<fg=green>running</>',
+			],
+			[
+				'service' => 'php',
+				'winname' => 'valet_phpcgi',
+				'status' => '<fg=green>running</>',
+			],
+			[
+				'service' => 'php-xdebug',
+				'winname' => 'valet_phpcgi_xdebug',
+				'status' => '<fg=green>running</>',
+			],
+		], $services);
+	}
 }

--- a/tests/WinSWTest.php
+++ b/tests/WinSWTest.php
@@ -11,77 +11,77 @@ use Valet\WinSwFactory;
 
 class WinSWTest extends TestCase
 {
-    /** @test */
-    public function make_winsw()
-    {
-        $winsw = resolve(WinSwFactory::class)->make('testservice');
+	/** @test */
+	public function make_winsw()
+	{
+		$winsw = resolve(WinSwFactory::class)->make('testservice');
 
-        $this->assertInstanceOf(WinSW::class, $winsw);
-    }
+		$this->assertInstanceOf(WinSW::class, $winsw);
+	}
 
-    /** @test */
-    public function install_service()
-    {
-        $this->mock(Filesystem::class)
-            ->shouldReceive('get')->andReturnUsing(function ($path) {
-                $this->assertSame(realpath(__DIR__.'/../cli/Valet').'/../stubs/testservice.xml', $path);
-            })->once()
-            ->shouldReceive('put')->andReturnUsing(function ($path) {
-                $this->assertSame(Valet::homePath('Services\testservice.xml'), $path);
-            })->once()
-            ->shouldReceive('copy')->andReturnUsing(function ($from, $to) {
-                $this->assertSame(realpath(__DIR__.'/../bin/winsw/WinSW.NET4.exe'), $from);
-                $this->assertSame(Valet::homePath('Services\testservice.exe'), $to);
-            })->once();
+	/** @test */
+	public function install_service()
+	{
+		$this->mock(Filesystem::class)
+			->shouldReceive('get')->andReturnUsing(function ($path) {
+				$this->assertSame(realpath(__DIR__.'/../cli/Valet').'/../stubs/testservice.xml', $path);
+			})->once()
+			->shouldReceive('put')->andReturnUsing(function ($path) {
+				$this->assertSame(Valet::homePath('Services\testservice.xml'), $path);
+			})->once()
+			->shouldReceive('copy')->andReturnUsing(function ($from, $to) {
+				$this->assertSame(realpath(__DIR__.'/../bin/winsw/WinSW.NET4.exe'), $from);
+				$this->assertSame(Valet::homePath('Services\testservice.exe'), $to);
+			})->once();
 
-        $this->mock(CommandLine::class)
-            ->shouldReceive('runOrExit')->andReturnUsing(function ($command) {
-                $this->assertSame('cmd "/C cd '.Valet::homePath('Services').' && "'.Valet::homePath('Services\testservice').'" install"', $command);
-            })->once();
+		$this->mock(CommandLine::class)
+			->shouldReceive('runOrExit')->andReturnUsing(function ($command) {
+				$this->assertSame('cmd "/C cd '.Valet::homePath('Services').' && "'.Valet::homePath('Services\testservice').'" install"', $command);
+			})->once();
 
-        $this->winsw('testservice')->install();
-    }
+		$this->winsw('testservice')->install();
+	}
 
-    /** @test */
-    public function stop_service()
-    {
-        $this->mock(CommandLine::class)
-            ->shouldReceive('run')->andReturnUsing(function ($command) {
-                $this->assertSame('cmd "/C cd '.Valet::homePath('Services').' && "'.Valet::homePath('Services\testservice').'" stop"', $command);
-            })->once();
+	/** @test */
+	public function stop_service()
+	{
+		$this->mock(CommandLine::class)
+			->shouldReceive('run')->andReturnUsing(function ($command) {
+				$this->assertSame('cmd "/C cd '.Valet::homePath('Services').' && "'.Valet::homePath('Services\testservice').'" stop"', $command);
+			})->once();
 
-        $this->winsw('testservice')->stop();
-    }
+		$this->winsw('testservice')->stop();
+	}
 
-    /** @test */
-    public function restart_service()
-    {
-        $this->mock(CommandLine::class)
-            ->shouldReceive('run')->andReturnUsing(function ($command) {
-                $this->assertSame('cmd "/C cd '.Valet::homePath('Services').' && "'.Valet::homePath('Services\testservice').'" restart"', $command);
-            })->once();
+	/** @test */
+	public function restart_service()
+	{
+		$this->mock(CommandLine::class)
+			->shouldReceive('run')->andReturnUsing(function ($command) {
+				$this->assertSame('cmd "/C cd '.Valet::homePath('Services').' && "'.Valet::homePath('Services\testservice').'" restart"', $command);
+			})->once();
 
-        $this->winsw('testservice')->restart();
-    }
+		$this->winsw('testservice')->restart();
+	}
 
-    /** @test */
-    public function uninstall_service()
-    {
-        $this->mock(CommandLine::class)
-            ->shouldReceive('run')->once()
-            ->shouldReceive('run')->andReturnUsing(function ($command) {
-                $this->assertSame('cmd "/C cd '.Valet::homePath('Services').' && "'.Valet::homePath('Services\testservice').'" uninstall"', $command);
-            })->once();
+	/** @test */
+	public function uninstall_service()
+	{
+		$this->mock(CommandLine::class)
+			->shouldReceive('run')->once()
+			->shouldReceive('run')->andReturnUsing(function ($command) {
+				$this->assertSame('cmd "/C cd '.Valet::homePath('Services').' && "'.Valet::homePath('Services\testservice').'" uninstall"', $command);
+			})->once();
 
-        $this->winsw('testservice')->uninstall();
-    }
+		$this->winsw('testservice')->uninstall();
+	}
 
-    /**
-     * @param  string  $service
-     * @return \Valet\WinSW
-     */
-    protected function winsw(string $service): WinSW
-    {
-        return resolve(WinSwFactory::class)->make($service);
-    }
+	/**
+	 * @param  string  $service
+	 * @return \Valet\WinSW
+	 */
+	protected function winsw(string $service): WinSW
+	{
+		return resolve(WinSwFactory::class)->make($service);
+	}
 }


### PR DESCRIPTION
Patch 2 improves Patch 1 from damsfx (adds PHP version to `valet links` command output):

- Additions to command `valet parked`:
     - PHP version both default and isolated, with a green colour for emphasis on the latter.
     - Alias and Alias URL - if the parked site also has a symbolic link, it's linked name (aka alias) and alias url will be added.
- Changes:
     -  The output table is now vertical for easier reading, especially because of the additions for the parked command.
     - Indents to use tabs instead of spaces, and other linting.
- New command:
     - `php:which` - To determine which PHP version the current working directory is using. If the site has an alias, it uses the alias in the output.
     
 ```sh
$ valet parked
+-----------------------------------------+
|      Site: site1                        |
|     Alias:                              |
|       SSL:                              |
|       PHP: 8.0.17 (default)             |
|       URL: http://site1.local/          |
| Alias URL:                              |
|      Path: D:\_Sites\site1              |
+-----------------------------------------+
|      Site: another_site                 |
|     Alias: site2                        |
|       SSL:                              |
|       PHP: 7.4.33 (isolated)            |
|       URL: http://another_site.local/   |
| Alias URL: http://site2.local/          |
|      Path: D:\_Sites\another_site       |
+-----------------------------------------+


D:\_Sites\another_site
$ valet php:which
This site site2 is using PHP 7.4.33 (isolated)

```







