### PR TITLE
Refactor 'share' command for improved site handling

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -595,7 +595,7 @@ if (is_dir(VALET_HOME_PATH)) {
 
 	/**
 	 * Generate a publicly accessible URL for your project.
-	 * @param string $site The site
+	 * @param string $site The site [optional] we automatically use current working directory domain
 	 * @param array $options A space-separated array of options/flags to pass to ngrok.
 	 * ---
 	 * Pass the option name without the `--` prefix (so Valet doesn't get confused with it's own options); eg. `domain=example.com`.
@@ -608,7 +608,7 @@ if (is_dir(VALET_HOME_PATH)) {
 	 * @param bool $debug Allow debug error output
 	 */
 	$app->command(
-		'share [site] [options]* [--debug]',
+		'share [-s|--site=] [options]* [--debug]',
 		function ($site = null, $options = [], $debug) {
 
 			$url = ($site ?: strtolower(Site::host(getcwd()))) . '.' . Configuration::read()['tld'];


### PR DESCRIPTION
### Proposal to Enhance 'share' Command in Laravel Valet

Currently, when using the 'share' command, we often want to share our current working directory. Recentally ngrok start providing a default permanent domain for all free users. it makes sense to optimize the process for sharing projects without unnecessary repetitions.

My proposal is to make the 'site' parameter in the 'share' command optional. This change would allow us to automatically use the current working directory's domain when no site name is specified. This adjustment aligns well with common usage scenarios and reduces the need for repetitive input.

By making the 'site' parameter optional, we can streamline the sharing process for our projects and further enhance the user experience. Developers who wish to use ngrok options can do so without the frustration of passing the site name every time.


If we want to define a site name then we need to just pass name with `-s|--site` parameter.

Now:
```php
valet share site-1 domain=custom-domain
```
After:
```php
valet share domain=custom-domain //for current working directory
//or 
valet share -s site-1 domain=custom-domain //other site
valet share --site site-1 domain=custom-domain //other site
```



