### PR TITLE
Update compatible requirements for Laravel installer v5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 		}
 	},
 	"require": {
-		"php": "^8.2",
+		"php": "^7.4|^8.0|^8.2",
 		"illuminate/container": "^8.0|^9.0|^10.0|^11.0",
 		"mnapoli/silly": "^1.8",
 		"symfony/process": "^4.0|^5.0|^6.0|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -36,13 +36,13 @@
 		}
 	},
 	"require": {
-		"php": "^7.4|^8.0",
-		"illuminate/container": "^8.0|^9.0|^10.0",
+		"php": "^8.2",
+		"illuminate/container": "^8.0|^9.0|^10.0|^11.0",
 		"mnapoli/silly": "^1.8",
 		"symfony/process": "^4.0|^5.0|^6.0|^7.0",
 		"guzzlehttp/guzzle": "^7.7",
 		"phpseclib/phpseclib": "^3.0",
-		"illuminate/collections": "^8.0|^9.0|^10.0",
+		"illuminate/collections": "^8.0|^9.0|^10.0|^11.0",
 		"composer/ca-bundle": "^1.3"
 	},
 	"conflict": {


### PR DESCRIPTION
Laravel Installer v5.6 requirements:

- PHP 8.2
- `illuminate/*` version add ^11.0