### PR TITLE
Changed AcrylicDNS binding address to localhost loopback address

### DIFF
--- a/bin/acrylic/AcrylicConfiguration.ini
+++ b/bin/acrylic/AcrylicConfiguration.ini
@@ -406,7 +406,14 @@ AddressCacheDisabled=No
 ; corresponding to the IPv4 address of one of your network interfaces instead will allow Acrylic to receive DNS requests
 ; only from that specific network interface. An empty value instead indicates that no binding should occur on IPv4.
 ;
-LocalIPv4BindingAddress=0.0.0.0
+; Binding to Acrylic to 0.0.0.0 has a known issue of causing problems with WSL2 which depends on port 53
+; By binding Acrylic to the localhost loopback address (127.0.0.1), this prevents it from blocking port 53
+; on the WSL2 vEthernet interface.
+; If Acrylic should handle DNS request for all network interfaces, then as an alternative, this should be set to 0.0.0.0
+; and LocalIPv4BindingPort should be changed to a port other than 53
+; See: https://github.com/microsoft/WSL/issues/4364#issuecomment-866700145
+;
+LocalIPv4BindingAddress=127.0.0.1
 ;
 ; The local UDPv4 port to which Acrylic binds. The default value of 53 is the standard port for DNS resolution. You
 ; should change this value only if you are using a non standard DNS client.


### PR DESCRIPTION
Changed AcrylicDNS binding address to localhost loopback address to avoid conflicting with WSL2 dependency.

See: https://github.com/microsoft/WSL/issues/4364#issuecomment-866700145