### PR TITLE
Fix: PHP 8.4 implicit nullable deprecation notice

### DIFF
--- a/cli/Valet/CommandLine.php
+++ b/cli/Valet/CommandLine.php
@@ -37,7 +37,7 @@ class CommandLine {
 	 * @param boolean $realTimeOutput Set to `true` to get the output in real time as the command is running. Default: `false`
 	 * @return ProcessOutput
 	 */
-	public function run($command, callable $onError = null, $realTimeOutput = false) {
+	public function run($command, callable|null $onError = null, $realTimeOutput = false){
 		return $this->runCommand($command, $onError, $realTimeOutput);
 	}
 
@@ -49,7 +49,7 @@ class CommandLine {
 	 * @param boolean $realTimeOutput Set to `true` to get the output in real time as the command is running. Default: `false`
 	 * @return ProcessOutput
 	 */
-	public function runAsUser($command, callable $onError = null, $realTimeOutput = false) {
+	public function runAsUser($command, callable|null $onError = null, $realTimeOutput = false) {
 		return $this->runCommand($command, $onError, $realTimeOutput);
 	}
 
@@ -61,7 +61,7 @@ class CommandLine {
 	 * @param boolean $realTimeOutput Set to `true` to get the output in real time as the command is running. Default: `false`
 	 * @return ProcessOutput
 	 */
-	public function powershell(string $command, callable $onError = null, $realTimeOutput = false) {
+	public function powershell(string $command, callable|null $onError = null, $realTimeOutput = false) {
 		return $this->runCommand("powershell -command \"$command\"", $onError, $realTimeOutput);
 	}
 
@@ -73,7 +73,7 @@ class CommandLine {
 	 * @param boolean $realTimeOutput Set to `true` to get the output in real time as the command is running. Default: `false`
 	 * @return ProcessOutput
 	 */
-	public function runOrExit($command, callable $onError = null, $realTimeOutput = false) {
+	public function runOrExit($command, callable|null $onError = null, $realTimeOutput = false) {
 		return $this->run($command, function ($code, $output) use ($onError) {
 			if ($onError) {
 				$onError($code, $output);
@@ -91,7 +91,7 @@ class CommandLine {
 	 * @param boolean $realTimeOutput Set to `true` to get the output in real time as the command is running. Default: `false`
 	 * @return ProcessOutput|void Returns a ProcessOutput only if the real time is `false`, otherwise it doesn't return anything (void) as it's echoing out in real time.
 	 */
-	public function runCommand($command, callable $onError = null, $realTimeOutput = false) {
+	public function runCommand($command, callable|null $onError = null, $realTimeOutput = false) {
 		$onError = $onError ?: function () {
 		};
 

--- a/cli/Valet/CommandLine.php
+++ b/cli/Valet/CommandLine.php
@@ -37,7 +37,7 @@ class CommandLine {
 	 * @param boolean $realTimeOutput Set to `true` to get the output in real time as the command is running. Default: `false`
 	 * @return ProcessOutput
 	 */
-	public function run($command, callable|null $onError = null, $realTimeOutput = false){
+	public function run($command, ?callable $onError = null, $realTimeOutput = false) {
 		return $this->runCommand($command, $onError, $realTimeOutput);
 	}
 
@@ -49,7 +49,7 @@ class CommandLine {
 	 * @param boolean $realTimeOutput Set to `true` to get the output in real time as the command is running. Default: `false`
 	 * @return ProcessOutput
 	 */
-	public function runAsUser($command, callable|null $onError = null, $realTimeOutput = false) {
+	public function runAsUser($command, ?callable $onError = null, $realTimeOutput = false) {
 		return $this->runCommand($command, $onError, $realTimeOutput);
 	}
 
@@ -61,7 +61,7 @@ class CommandLine {
 	 * @param boolean $realTimeOutput Set to `true` to get the output in real time as the command is running. Default: `false`
 	 * @return ProcessOutput
 	 */
-	public function powershell(string $command, callable|null $onError = null, $realTimeOutput = false) {
+	public function powershell(string $command, ?callable $onError = null, $realTimeOutput = false) {
 		return $this->runCommand("powershell -command \"$command\"", $onError, $realTimeOutput);
 	}
 
@@ -73,7 +73,7 @@ class CommandLine {
 	 * @param boolean $realTimeOutput Set to `true` to get the output in real time as the command is running. Default: `false`
 	 * @return ProcessOutput
 	 */
-	public function runOrExit($command, callable|null $onError = null, $realTimeOutput = false) {
+	public function runOrExit($command, ?callable $onError = null, $realTimeOutput = false) {
 		return $this->run($command, function ($code, $output) use ($onError) {
 			if ($onError) {
 				$onError($code, $output);
@@ -91,7 +91,7 @@ class CommandLine {
 	 * @param boolean $realTimeOutput Set to `true` to get the output in real time as the command is running. Default: `false`
 	 * @return ProcessOutput|void Returns a ProcessOutput only if the real time is `false`, otherwise it doesn't return anything (void) as it's echoing out in real time.
 	 */
-	public function runCommand($command, callable|null $onError = null, $realTimeOutput = false) {
+	public function runCommand($command, ?callable $onError = null, $realTimeOutput = false) {
 		$onError = $onError ?: function () {
 		};
 

--- a/cli/Valet/Ngrok.php
+++ b/cli/Valet/Ngrok.php
@@ -120,7 +120,7 @@ Then use: <fg=magenta>valet set-ngrok-token [token]</>');
 	 * @return string|null
 	 * @return void|string
 	 */
-	public function findHttpTunnelUrl(array $tunnels, string $site = null) {
+	public function findHttpTunnelUrl(array $tunnels, ?string $site = null) {
 		// If there are active tunnels on the ngrok instance we will spin through them and
 		// find the one responding on HTTP. Each tunnel has an HTTP and a HTTPS address
 		// but for local dev purposes we just desire the plain HTTP URL endpoint.


### PR DESCRIPTION
fix: Update `CommandLine` methods to use explicit nullable types

Update function signatures to use explicit nullable type declaration for `$onError` parameter to address PHP deprecation notice. Changed from `callable $onError = null` to `callable|null $onError = null`

Fixes #16