### PR TITLE
fix: correct legacy drivers path in require-drivers.php

### DIFF
--- a/cli/includes/require-drivers.php
+++ b/cli/includes/require-drivers.php
@@ -38,7 +38,7 @@ foreach (scandir($specificDriversDir) as $file) {
 }
 
 // Require legacy drivers.
-$legacyDriversDir = "$includesDir/legacy";
+$legacyDriversDir = "$includesDir/legacy_drivers";
 
 foreach (scandir($legacyDriversDir) as $file) {
 	if (substr($file, 0, 1) !== '.') {


### PR DESCRIPTION
In PR #29, commit 8a94888, the path for the legacy driver directory was wrongly changed, so now legacy drivers won't load and PHP spits out errors.

- Fixed legacy driver path so the legacy drivers will now load.