### PR TITLE
fix: replacing php port for isolation.

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -980,7 +980,8 @@ class Site {
 	 * @return array|string|null
 	 */
 	public function replacePhpVersionInSiteConf($siteConf, $phpPort, $phpVersion = null) {
-		$siteConf = str_replace('127.0.0.1:$valet_php_port;', "127.0.0.1:{$phpPort};", $siteConf);
+		// Replace both the variable $valet_php_port and any existing specific port numbers
+		$siteConf = preg_replace('/127\.0\.0\.1:(?:\$valet_php_port|\d+);/', "127.0.0.1:{$phpPort};", $siteConf);
 
 		// Remove `Valet isolated PHP version` line from config
 		$siteConf = preg_replace('/# Valet isolated PHP version.*\n/', '', $siteConf);


### PR DESCRIPTION
On non-isolated sites that are being isolated, the replacement of the `$valet_php_port` variable to the actual port number works fine. But if an already isolated site was to be reisolated to a different php version, then the port wouldn't be changed because the `$valet_php_port` is no longer there, as it's the current port number instead. Thus making the isolation null and void and the site will still be served on the original isolated php version on the original port.

- Fixed port replacement for isolation by changing it to a regex to both replace the `$valet_php_port` and any number after the localhost IP address.