### PR TITLE
feat: allow nginx 500 error page to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,16 @@ composer global require ycodetech/valet-windows
     <td></td>
 		<td align="center"><a href="#parity">parity</a></td>
   </tr>
+  
+  <tr>
+  <th></th>
+    <td></td>
+    <td></td>
+    <td></td>
+		<td></td>
+    <td></td>
+		<td align="center"><a href="#nginx-error-page">nginx-error-page</a></td>
+  </tr>
 </table>
 
 ## Introduction
@@ -1420,6 +1430,23 @@ Parity at 87% out of a total 92% possible parity with the Laravel Valet (macOS) 
 ```
 
 This command is a way to determine how much parity has been achieved.
+
+##### nginx-error-page
+
+```
+nginx-error-page               Display the current visibility of the nginx error page.
+                 [visibility]  Optionally, set to "on" to enable Valet's nginx error page, or "off" to disable it.
+```
+
+```console
+$ valet nginx-error-page
+Valet's nginx error pages are on.
+
+$ valet nginx-error-page off
+Valet's nginx error pages are now off.
+```
+
+The nginx error pages are `on` (enabled) by default, which means that Valet's custom nginx 404/500 error pages will be shown when an error is encountered. However, for those who prefer to use a framework's error reporting exception pages like that of Symfony or Laravel, Valet's nginx error pages can be turned `off` (disabled).
 
 ---
 

--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -167,6 +167,30 @@ class Configuration {
 	}
 
 	/**
+	 * Add any missing necessary default configuration keys.
+	 *
+	 * It will not overwrite any existing configuration values,
+	 * only add missing keys with default values.
+	 */
+	public function addMissingDefaultConfigKeys() {
+		$config = $this->read();
+
+		// Add default_php if missing or is null.
+		if (!isset($config['default_php']) || $config['default_php'] === null) {
+			$this->addDefaultPhp();
+		}
+
+		// Add tld if missing.
+		$this->updateKey('tld', $config['tld'] ?? 'test');
+		// Add php_port if missing.
+		$this->updateKey('php_port', $config['php_port'] ?? PhpCgi::PORT);
+		// Add the default php_xdebug_port if missing.
+		$this->updateKey('php_xdebug_port', $config['php_xdebug_port'] ?? PhpCgiXdebug::PORT);
+		// Add share-tool if missing.
+		$this->updateKey('share-tool', $config['share-tool'] ?? 'ngrok');
+	}
+
+	/**
 	 * Forcefully delete the Valet home configuration directory and contents.
 	 */
 	public function uninstall() {
@@ -476,29 +500,5 @@ class Configuration {
 	 */
 	protected function valetHomePath(string $path = ''): string {
 		return Valet::homePath($path);
-	}
-
-	/**
-	 * Add any missing necessary default configuration keys.
-	 *
-	 * It will not overwrite any existing configuration values,
-	 * only add missing keys with default values.
-	 */
-	public function addMissingDefaultConfigKeys() {
-		$config = $this->read();
-
-		// Add default_php if missing or is null.
-		if (!isset($config['default_php']) || $config['default_php'] === null) {
-			$this->addDefaultPhp();
-		}
-
-		// Add tld if missing.
-		$this->updateKey('tld', $config['tld'] ?? 'test');
-		// Add php_port if missing.
-		$this->updateKey('php_port', $config['php_port'] ?? PhpCgi::PORT);
-		// Add the default php_xdebug_port if missing.
-		$this->updateKey('php_xdebug_port', $config['php_xdebug_port'] ?? PhpCgiXdebug::PORT);
-		// Add share-tool if missing.
-		$this->updateKey('share-tool', $config['share-tool'] ?? 'ngrok');
 	}
 }

--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -156,7 +156,8 @@ class Configuration {
 				'paths' => [$this->valetHomePath('Sites')],
 				'php_port' => PhpCgi::PORT,
 				'php_xdebug_port' => PhpCgiXdebug::PORT,
-				'share-tool' => 'ngrok'
+				'share-tool' => 'ngrok',
+				'nginx_error_page' => 'on'
 			];
 
 			$this->write($baseConfig);
@@ -188,6 +189,8 @@ class Configuration {
 		$this->updateKey('php_xdebug_port', $config['php_xdebug_port'] ?? PhpCgiXdebug::PORT);
 		// Add share-tool if missing.
 		$this->updateKey('share-tool', $config['share-tool'] ?? 'ngrok');
+		// Add nginx_error_page if missing.
+		$this->updateKey('nginx_error_page', $config['nginx_error_page'] ?? 'on');
 	}
 
 	/**

--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -149,6 +149,7 @@ class Configuration {
 	 * Write the base, initial configuration for Valet.
 	 */
 	public function writeBaseConfiguration() {
+		// If the configuration file doesn't exist, create it with the base configuration.
 		if (!$this->files->exists($this->path())) {
 			$baseConfig = [
 				'tld' => 'test',
@@ -161,21 +162,8 @@ class Configuration {
 			$this->write($baseConfig);
 		}
 
-		$config = $this->read();
-
-		// Add default_php if missing or is null.
-		if (!isset($config['default_php']) || $config['default_php'] === null) {
-			$this->addDefaultPhp();
-		}
-
-		// Add tld if missing.
-		$this->updateKey('tld', $config['tld'] ?? 'test');
-		// Add php_port if missing.
-		$this->updateKey('php_port', $config['php_port'] ?? PhpCgi::PORT);
-		// Add the default php_xdebug_port if missing.
-		$this->updateKey('php_xdebug_port', $config['php_xdebug_port'] ?? PhpCgiXdebug::PORT);
-		// Add share-tool if missing.
-		$this->updateKey('share-tool', $config['share-tool'] ?? 'ngrok');
+		// If the configuration file exists, ensure it has all the necessary keys.
+		$this->addMissingDefaultConfigKeys();
 	}
 
 	/**
@@ -488,5 +476,29 @@ class Configuration {
 	 */
 	protected function valetHomePath(string $path = ''): string {
 		return Valet::homePath($path);
+	}
+
+	/**
+	 * Add any missing necessary default configuration keys.
+	 *
+	 * It will not overwrite any existing configuration values,
+	 * only add missing keys with default values.
+	 */
+	public function addMissingDefaultConfigKeys() {
+		$config = $this->read();
+
+		// Add default_php if missing or is null.
+		if (!isset($config['default_php']) || $config['default_php'] === null) {
+			$this->addDefaultPhp();
+		}
+
+		// Add tld if missing.
+		$this->updateKey('tld', $config['tld'] ?? 'test');
+		// Add php_port if missing.
+		$this->updateKey('php_port', $config['php_port'] ?? PhpCgi::PORT);
+		// Add the default php_xdebug_port if missing.
+		$this->updateKey('php_xdebug_port', $config['php_xdebug_port'] ?? PhpCgiXdebug::PORT);
+		// Add share-tool if missing.
+		$this->updateKey('share-tool', $config['share-tool'] ?? 'ngrok');
 	}
 }

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -88,11 +88,14 @@ class Nginx {
 
 		$valetErrorTemplatePath = $this->files->realpath(valetBinPath() . '../cli/templates');
 
+		// Check if nginx error pages are disabled
+		$interceptErrors = $this->configuration->get('nginx_error_page');
+
 		$this->files->putAsUser(
 			$this->path('valet/valet.conf'),
 			str_replace(
-				['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'HOME_PATH', 'VALET_PHP_PORT', 'VALET_ERROR_TEMPLATE_PATH'],
-				[Valet::homePath(), VALET_SERVER_PATH, VALET_STATIC_PREFIX, $_SERVER['HOME'], $defaultPhp['port'], $valetErrorTemplatePath],
+				['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'HOME_PATH', 'VALET_PHP_PORT', 'VALET_ERROR_TEMPLATE_PATH', 'VALET_INTERCEPT_ERRORS'],
+				[Valet::homePath(), VALET_SERVER_PATH, VALET_STATIC_PREFIX, $_SERVER['HOME'], $defaultPhp['port'], $valetErrorTemplatePath, $interceptErrors],
 				$this->files->getStub('valet.conf')
 			)
 		);

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -309,7 +309,7 @@ class Site {
 	}
 
 	/**
-	 * Extract PHP version of exising nginx config.
+	 * Extract PHP version of existing nginx config.
 	 *
 	 * @param string $url
 	 *

--- a/cli/Valet/Upgrader.php
+++ b/cli/Valet/Upgrader.php
@@ -36,6 +36,7 @@ class Upgrader {
 			$this->lintNginxConfigs();
 			$this->upgradeNginxSiteConfigs();
 			$this->fixOldSampleValetDriver();
+			$this->addMissingConfigKeys();
 		}
 	}
 
@@ -190,5 +191,12 @@ class Upgrader {
 				);
 			}
 		}
+	}
+
+	/**
+	 * Add any missing necessary default configuration keys.
+	 */
+	public function addMissingConfigKeys() {
+		$this->config->addMissingDefaultConfigKeys();
 	}
 }

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -45,7 +45,7 @@ server {
         fastcgi_param HOME "HOME_PATH";
         fastcgi_param PATH_INFO $fastcgi_path_info;
 
-        fastcgi_intercept_errors on;
+        fastcgi_intercept_errors VALET_INTERCEPT_ERRORS;
     }
 
     location ~ /\.ht {

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -405,22 +405,22 @@ $app->command('services', function () {
 })->descriptions('List the installed Valet services.');
 
 /**
- * Display the current visibility of the nginx error page, or optionally
- * update its visibility to enable or disable it.
+ * Display the current visibility of the nginx error pages, or optionally
+ * update its visibility to enable or disable them.
  *
- * Valet's nginx error page is shown when a site has internal server or PHP errors.
- * It is enabled by default, but can be disabled to allow any 3rd party error
+ * Valet's nginx error pages are shown when a site has internal server or PHP errors.
+ * They are enabled by default, but can be disabled to allow any 3rd party error
  * reporting tools to show instead.
  *
- * @param string $visibility Optionally, set to `on` to enable Valet's nginx 500 error page, or `off` to disable it. Default is `on`.
+ * @param string $visibility Optionally, set to `on` to enable Valet's nginx error pages, or `off` to disable them. Default is `on`.
  */
 $app->command('nginx-error-page [visibility]', function ($visibility = null) {
 	$key = 'nginx_error_page';
 	$current = Configuration::get($key);
 
-	// If no visibility argument was passed, output the current status of the nginx error page.
+	// If no visibility argument was passed, output the current status of the nginx error pages.
 	if ($visibility == null) {
-		return info("Valet's nginx 500 error page is $current.");
+		return info("Valet's nginx error pages are $current.");
 	}
 
 	// If the visibility argument is valid...
@@ -429,7 +429,7 @@ $app->command('nginx-error-page [visibility]', function ($visibility = null) {
 		// This avoids unnecessary nginx config rewrites when the user tries to set the visibility
 		// to its current value.
 		if ($visibility === $current) {
-			return info("Valet's nginx 500 error page is already $visibility.");
+			return info("Valet's nginx error pages are already $visibility.");
 		}
 
 		// Update the configuration value for the nginx error page visibility.
@@ -439,15 +439,15 @@ $app->command('nginx-error-page [visibility]', function ($visibility = null) {
 		Nginx::installServer();
 		Nginx::restart();
 
-		return info("Valet's nginx 500 error page is now $visibility.");
+		return info("Valet's nginx error pages are now $visibility.");
 	}
 	// If the visibility argument is invalid, output an error message.
 	else {
 		return warning("Invalid visibility. Please set to either 'on' or 'off'.");
 	}
 
-})->descriptions("Display the current visibility of Valet's nginx 500 error page, or optionally update its visibility to enable or disable it.", [
-	'visibility' => "<fg=green>[on = default]</> will show Valet's 500 error page \n <fg=green>[off]</> will disable it."
+})->descriptions("Display the current visibility of Valet's nginx error pages, or optionally update its visibility to enable or disable them.", [
+	'visibility' => "<fg=green>[on = default]</> will show Valet's nginx error pages \n <fg=green>[off]</> will disable them."
 ]);
 
 /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -405,6 +405,52 @@ $app->command('services', function () {
 })->descriptions('List the installed Valet services.');
 
 /**
+ * Display the current visibility of the nginx error page, or optionally
+ * update its visibility to enable or disable it.
+ *
+ * Valet's nginx error page is shown when a site has internal server or PHP errors.
+ * It is enabled by default, but can be disabled to allow any 3rd party error
+ * reporting tools to show instead.
+ *
+ * @param string $visibility Optionally, set to `on` to enable Valet's nginx 500 error page, or `off` to disable it. Default is `on`.
+ */
+$app->command('nginx-error-page [visibility]', function ($visibility = null) {
+	$key = 'nginx_error_page';
+	$current = Configuration::get($key);
+
+	// If no visibility argument was passed, output the current status of the nginx error page.
+	if ($visibility == null) {
+		return info("Valet's nginx 500 error page is $current.");
+	}
+
+	// If the visibility argument is valid...
+	if (in_array($visibility, ['on', 'off'])) {
+		// If the visibility is the same as the current value, output a message and return early.
+		// This avoids unnecessary nginx config rewrites when the user tries to set the visibility
+		// to its current value.
+		if ($visibility === $current) {
+			return info("Valet's nginx 500 error page is already $visibility.");
+		}
+
+		// Update the configuration value for the nginx error page visibility.
+		Configuration::updateKey($key, $visibility);
+
+		// Re-install nginx server config and restart nginx to apply the change.
+		Nginx::installServer();
+		Nginx::restart();
+
+		return info("Valet's nginx 500 error page is now $visibility.");
+	}
+	// If the visibility argument is invalid, output an error message.
+	else {
+		return warning("Invalid visibility. Please set to either 'on' or 'off'.");
+	}
+
+})->descriptions("Display the current visibility of Valet's nginx 500 error page, or optionally update its visibility to enable or disable it.", [
+	'visibility' => "<fg=green>[on = default]</> will show Valet's 500 error page \n <fg=green>[off]</> will disable it."
+]);
+
+/**
  * Most commands are available only if Valet is installed.
  */
 if (is_dir(Valet::homePath()) && Nginx::isInstalled()) {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,6 +13,7 @@
 	<exclude-pattern>web/app/plugins</exclude-pattern>
 	<exclude-pattern>web/app/mu-plugins</exclude-pattern>
 	<exclude-pattern>vendor/</exclude-pattern>
+	<exclude-pattern>node_modules/</exclude-pattern>
 	<exclude-pattern>web/app/uploads/</exclude-pattern>
 
 	<!-- Show colors in console -->


### PR DESCRIPTION
Closes #31 

This PR introduces a new cli command for controlling the visibility of **all** Valet's custom nginx error pages (**both 404 and 500**), updates nginx configuration handling to respect this setting, and enable the error pages by default. Additionally, it includes minor improvements to configuration management and code quality.

**Nginx error page configurability:**

* Added a new `nginx_error_page` configuration key (default `'on'`) to control whether Valet's nginx error page is enabled. This key will now be included for new configs, and for existing configs, it will automatically be added if it's missing via the Upgrader processes.

* Updated Valet's main nginx config stub, and add logic to use the `nginx_error_page` setting in the `Nginx::installServer` method, allowing dynamic enabling or disabling of Valet's error pages.

* Added a new `valet nginx-error-page` CLI command to display or update the visibility of the nginx error pages, including automatic nginx reload when changed.

**Configuration and Upgrader:**

* Extracted the "missing default config keys" code from `writeBaseConfiguration` into a new `addMissingDefaultConfigKeys` Configuration method for better maintainability and to enable it's usage in the Upgrader.

* Added new `addMissingConfigKeys` Upgrader method to call the `addMissingDefaultConfigKeys` Configuration method during upgrades to add any missing default config keys to existing installations.