### PR TITLE
fix: replacing php port for isolation also replaced all non-php ports

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -976,15 +976,26 @@ class Site {
 	 *
 	 * @param string $siteConf
 	 * @param string $phpPort
+	 * @param string|null $phpVersion
 	 *
 	 * @return array|string|null
 	 */
 	public function replacePhpVersionInSiteConf($siteConf, $phpPort, $phpVersion = null) {
-		// Replace both the variable $valet_php_port and any existing specific port numbers
-		$siteConf = preg_replace('/127\.0\.0\.1:(?:\$valet_php_port|\d+);/', "127.0.0.1:{$phpPort};", $siteConf);
-
 		// Remove `Valet isolated PHP version` line from config
-		$siteConf = preg_replace('/# Valet isolated PHP version.*\n/', '', $siteConf);
+		$siteConf = preg_replace('/^# Valet isolated PHP version.*\R/m', '', $siteConf);
+
+		// If a specific PHP version is provided, use that port value,
+		// otherwise use the global variable.
+		$phpPortValue = $phpVersion ? $phpPort : '$valet_php_port';
+
+		// Replace existing port number or global variable with the new port value
+		// or global variable, depending on whether the site is isolated or not.
+		$siteConf = preg_replace(
+			'/(^\s*set \$valet_site_php_port\s+)[^;]+(\s*;)/m',
+			"$1{$phpPortValue}$2",
+			$siteConf,
+			1
+		);
 
 		if ($phpVersion) {
 			$siteConf = '# Valet isolated PHP version : ' . $phpVersion . PHP_EOL . $siteConf;

--- a/cli/Valet/Upgrader.php
+++ b/cli/Valet/Upgrader.php
@@ -42,6 +42,7 @@ class Upgrader {
 			$this->upgradeSymbolicLinks();
 			$this->upgradeDeprecatedNginxConfigDirectives();
 			$this->fixOldSampleValetDriver();
+			$this->upgradeNginxSitePhpPortOverrides();
 		}
 	}
 
@@ -248,5 +249,59 @@ class Upgrader {
 				);
 			}
 		}
+	}
+
+	/**
+	 * Upgrade all Nginx site configs to use per-site PHP port overrides.
+	 */
+	private function upgradeNginxSitePhpPortOverrides() {
+		// If the PHP port definitions have already been upgraded, skip.
+		if (!$this->shouldUpgradeNginxSitePhpPortOverrides()) {
+			return;
+		}
+
+		// If the Nginx config directory doesn't exist, skip and mark it as upgraded to prevent
+		// this from running again.
+		if (!$this->files->exists($this->site->nginxPath())) {
+			$this->config->updateKey('php_port_overrides_upgraded', true);
+			return;
+		}
+
+		$upgraded = 0;
+		$tld = $this->config->read()['tld'];
+
+		// Get all the Nginx config files for the sites.
+		foreach ($this->files->scandir($this->site->nginxPath()) as $file) {
+			// If the file doesn't end with ".{tld}.conf", skip it.
+			if (!str_ends_with($file, ".{$tld}.conf")) {
+				continue;
+			}
+
+			// Remove the ".conf" extension from the filename to get the site name.
+			$site = basename($file, '.conf');
+
+			// If the site has already been upgraded during this run, skip it.
+			if (isset($this->upgradedNginxSites[$site])) {
+				continue;
+			}
+
+			$this->upgradeNginxSiteConfigs($site);
+			$upgraded++;
+		}
+
+		if ($upgraded > 0) {
+			info("Upgraded {$upgraded} Nginx site config(s) to the new PHP port override format.");
+		}
+
+		$this->config->updateKey('php_port_overrides_upgraded', true);
+	}
+
+	/**
+	 * Determine whether Nginx site PHP port overrides should be upgraded.
+	 *
+	 * @return bool
+	 */
+	private function shouldUpgradeNginxSitePhpPortOverrides() {
+		return !$this->config->get('php_port_overrides_upgraded', false);
 	}
 }

--- a/cli/Valet/Upgrader.php
+++ b/cli/Valet/Upgrader.php
@@ -18,6 +18,13 @@ class Upgrader {
 	 */
 	protected $site;
 
+	/**
+	 * Sites that have had their Nginx configs upgraded during this run of Valet.
+	 *
+	 * @var array<string, bool>
+	 */
+	protected $upgradedNginxSites = [];
+
 	public function __construct(Filesystem $files, Configuration $config, Site $site) {
 		$this->files = $files;
 		$this->config = $config;
@@ -33,8 +40,7 @@ class Upgrader {
 			$this->prunePathsFromConfig();
 			$this->pruneSymbolicLinks();
 			$this->upgradeSymbolicLinks();
-			$this->lintNginxConfigs();
-			$this->upgradeNginxSiteConfigs();
+			$this->upgradeDeprecatedNginxConfigDirectives();
 			$this->fixOldSampleValetDriver();
 		}
 	}
@@ -116,17 +122,73 @@ class Upgrader {
 	/**
 	 * Upgrade Nginx site configurations.
 	 *
-	 * This method checks the Nginx configuration files for deprecated `http2` param
-	 * and `http2_push_preload` directive, then upgrades the site configurations accordingly.
+	 * To upgrade the Nginx config files for each site, this method will:
+	 * - Unisolate and reisolate isolated sites
+	 * - Delete and recreate proxy sites
+	 * - Unsecure and resecure secured sites
+	 *
+	 * @param string $site The site to upgrade.
 	 */
-	private function upgradeNginxSiteConfigs() {
+	private function upgradeNginxSiteConfigs($site) {
+		info("Upgrading Nginx config for site '{$site}'...");
+
+		$didUpgrade = false;
+
+		// If the site is isolated...
+		if ($this->site->isIsolated($site)) {
+			// Get the PHP version for the site.
+			$phpVersion = $this->site->customPhpVersion($site);
+
+			// Unisolate the site and re-isolate it using the phpVersion to
+			// upgrade the Nginx config file.
+			$this->site->unisolate($site);
+			$this->site->isolate($phpVersion, $site);
+			$didUpgrade = true;
+		}
+		// If the site is a proxy...
+		elseif ($this->site->isProxy($site)) {
+			// Get the proxy host and whether the site is secured.
+			$host = $this->site->getProxyHostForSite($site);
+			$secured = $this->site->isSecured($site);
+
+			// Delete the proxy and re-create it using the host and
+			// secured values to upgrade the Nginx config file.
+			$this->site->proxyDelete($site);
+			$this->site->proxyCreate($site, $host, $secured);
+			$didUpgrade = true;
+		}
+		// If the site is secured...
+		elseif ($this->site->isSecured($site)) {
+			// Unsecure the site and re-secure it to upgrade
+			// the Nginx config file.
+			$this->site->unsecure($site);
+			$this->site->secure($site);
+			$didUpgrade = true;
+		}
+
+		if ($didUpgrade) {
+			$this->upgradedNginxSites[$site] = true;
+		}
+	}
+
+	/**
+	 * Upgrade deprecated Nginx configuration directives.
+	 *
+	 * This method checks the Nginx configuration files for deprecated `http2` param and `http2_push_preload` directive, then prompts the user to upgrade their Nginx site configurations accordingly.
+	 */
+	private function upgradeDeprecatedNginxConfigDirectives() {
 		$output = $this->lintNginxConfigs(true);
 
 		// If output is not empty...
 		if (!empty($output)) {
-			$stringsToCheck = ['the "listen ... http2" directive is deprecated', '"http2_push_preload" directive is obsolete'];
+			$stringsToCheck = [
+				'the "listen ... http2" directive is deprecated',
+				'"http2_push_preload" directive is obsolete'
+			];
 
 			$outputArray = explode("\r\n", $output);
+
+			$sitesToUpgrade = [];
 
 			// For each line in the output...
 			foreach ($outputArray as $line) {
@@ -139,36 +201,21 @@ class Upgrader {
 						// Get the site name from file path in the matched string,
 						// ie. gets the filename (site.conf) and removes the extension.
 						$site = basename($matches[1], ".conf");
-
-						// If the site is isolated...
-						if ($this->site->isIsolated($site)) {
-							// Get the PHP version for the site.
-							$phpVersion = $this->site->customPhpVersion($site);
-
-							// Unisolate the site and re-isolate it using the phpVersion to
-							// upgrade the Nginx config file.
-							$this->site->unisolate($site);
-							$this->site->isolate($phpVersion, $site);
-						}
-						// If the site is a proxy...
-						elseif ($this->site->isProxy($site)) {
-							// Get the proxy host and whether the site is secured.
-							$host = $this->site->getProxyHostForSite($site);
-							$secured = $this->site->isSecured($site);
-
-							// Delete the proxy and re-create it using the host and
-							// secured values to upgrade the Nginx config file.
-							$this->site->proxyDelete($site);
-							$this->site->proxyCreate($site, $host, $secured);
-						}
-						// If the site is secured...
-						elseif ($this->site->isSecured($site)) {
-							// Unsecure the site and re-secure it to upgrade
-							// the Nginx config file.
-							$this->site->unsecure($site);
-							$this->site->secure($site);
-						}
+						// Add the site to the sitesToUpgrade array.
+						// This ensures that if a site has multiple deprecated directives,
+						// it will only be added to the array once.
+						$sitesToUpgrade[$site] = true;
 					}
+				}
+			}
+
+			// If there are any sites to upgrade...
+			if (!empty($sitesToUpgrade)) {
+				warning('Your Nginx configuration files contain some deprecated directives that need to be updated.');
+
+				// Upgrade the Nginx config files for each site that needs to be upgraded.
+				foreach (array_keys($sitesToUpgrade) as $site) {
+					$this->upgradeNginxSiteConfigs($site);
 				}
 			}
 		}

--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -49,7 +49,8 @@ server {
 
     location ~ [^/]\.php(/|$) {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass 127.0.0.1:$valet_php_port;
+        set $valet_site_php_port $valet_php_port;
+        fastcgi_pass 127.0.0.1:$valet_site_php_port;
         fastcgi_index "VALET_SERVER_PATH";
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME "VALET_SERVER_PATH";
@@ -101,7 +102,8 @@ server {
 
     location ~ [^/]\.php(/|$) {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass 127.0.0.1:$valet_php_port;
+        set $valet_site_php_port $valet_php_port;
+        fastcgi_pass 127.0.0.1:$valet_site_php_port;
         fastcgi_index "VALET_SERVER_PATH";
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME "VALET_SERVER_PATH";

--- a/cli/stubs/unsecure.valet.conf
+++ b/cli/stubs/unsecure.valet.conf
@@ -39,7 +39,8 @@ server {
 
     location ~ [^/]\.php(/|$) {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass 127.0.0.1:$valet_php_port;
+        set $valet_site_php_port $valet_php_port;
+        fastcgi_pass 127.0.0.1:$valet_site_php_port;
         fastcgi_index "VALET_SERVER_PATH";
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME "VALET_SERVER_PATH";


### PR DESCRIPTION
A follow-up to PR #33 which introduced a bug that replaced **all** ports, not just the php-specific ones. So this meant that port 60, 80, etc. was all replaced which crashed nginx preventing it from obtaining and running the sites.

---

This pull request introduces significant improvements to how Nginx site configurations handle PHP port overrides in Valet, along with a more robust upgrade process for deprecated Nginx directives. The changes ensure per-site PHP port flexibility, automate config upgrades, and enhance maintainability.

**Nginx Site Configuration and PHP Port Handling:**

* Updated the Nginx config stubs (`secure.valet.conf` and `unsecure.valet.conf`) to use a new variable `valet_site_php_port` instead of directly referencing `valet_php_port`, allowing for per-site PHP port overrides.
* Refactored the `replacePhpVersionInSiteConf` method in `Site.php` to support replacing the PHP port with either a specific value or the global variable, and improved the removal of isolated PHP version comments.

**Upgrade and Migration Automation:**

* Added a new upgrade routine in `Upgrader.php` that scans all Nginx site configs and upgrades them to use the new per-site PHP port override format, ensuring this runs only once per install.
* Introduced a mechanism to track which sites have had their Nginx configs upgraded during a run to avoid redundant operations.

**Deprecated Directive Handling:**

* Replaced the previous inline upgrade logic with a new process that detects deprecated Nginx directives (`http2` and `http2_push_preload`), warns the user, and upgrades affected site configs automatically.

These changes collectively modernize Valet’s Nginx configuration management, making it more flexible and future-proof.

~ Summary generated by Copilot. For more detailed info, view the commit messages.