### PR TITLE
fix: php port replacement removes entire line in site config

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -992,7 +992,7 @@ class Site {
 		// or global variable, depending on whether the site is isolated or not.
 		$siteConf = preg_replace(
 			'/(^\s*set \$valet_site_php_port\s+)[^;]+(\s*;)/m',
-			"$1{$phpPortValue}$2",
+			'${1}' . $phpPortValue . '$2',
 			$siteConf,
 			1
 		);

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -993,8 +993,7 @@ class Site {
 		$siteConf = preg_replace(
 			'/(^\s*set \$valet_site_php_port\s+)[^;]+(\s*;)/m',
 			'${1}' . $phpPortValue . '$2',
-			$siteConf,
-			1
+			$siteConf
 		);
 
 		if ($phpVersion) {


### PR DESCRIPTION
Fixes #42.

This pull request makes a minor update to the way the PHP port is replaced in the site configuration within the `replacePhpVersionInSiteConf` function. The change simplifies the usage of replacement variables in the `preg_replace` call, improving readability and maintainability.

- Refactored the `preg_replace` replacement string in the `replacePhpVersionInSiteConf` function in `Site.php` to use string concatenation with `${1}` instead of double-quoted interpolation with `$1`, ensuring correct variable substitution and preventing entire line removal with the wrong interpretation of the backreference numbers.

- Removed the limit of max replacements the `preg_replace` can do, ensuring all PHP port lines in multiple location blocks in the site configs are replaced.