### PR TITLE
fix: `which` command bug that still uses the old `drivers/require.php` path.

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,5 +5,14 @@
 	"printWidth": 150,
 	"bracketSameLine": true,
 	"bracketSpacing": false,
-	"endOfLine": "crlf"
+	"endOfLine": "crlf",
+	"overrides": [
+		{
+			"files": "*.md",
+			"options": {
+				"useTabs": false,
+				"tabWidth": 4
+			}
+		}
+	]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/yCodeTech/valet-windows/tree/master)
 
+## [3.4.2](https://github.com/yCodeTech/valet-windows/tree/v3.4.2) - 2026-06-07
+
+### Fixed
+
+- Fixed [#45](https://github.com/yCodeTech/valet-windows/issues/45): `which` command bug that still uses the old `drivers/require.php` path; in [#46](https://github.com/yCodeTech/valet-windows/pull/46).
+
 ## [3.4.1](https://github.com/yCodeTech/valet-windows/tree/v3.4.1) - 2026-04-11
 
 ### Fixed

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -16,6 +16,7 @@ require_once __DIR__ . '/version.php';
 use Illuminate\Container\Container;
 use Valet\Application;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Valet\Drivers\ValetDriver;
 use function Valet\info;
 use function Valet\info_dump;
 use function Valet\output;
@@ -1236,7 +1237,8 @@ if (is_dir(Valet::homePath()) && Nginx::isInstalled()) {
 	 * Determine which Valet driver the current working directory is using
 	 */
 	$app->command('which', function () {
-		require __DIR__ . '/drivers/require.php';
+		// DEPRECATED: Remove this require with the rest of the legacy drivers code.
+		require __DIR__ . '/includes/require-drivers.php';
 
 		$driver = ValetDriver::assign(getcwd(), basename(getcwd()), '/');
 


### PR DESCRIPTION
Fixes #45.

- Fixed the require path in the `which` command, as it was still using the old require drivers path, it now uses the new `includes/require-drivers.php` path. Otherwise this bug would spit out a PHP warning:

  > PHP Warning:  require(C:\Users\Name\AppData\Roaming\Composer\vendor\ycodetech\valet-windows\cli/drivers/require.php): Failed to open stream: No such file or directory in C:\Users\Name\AppData\Roaming\Composer\vendor\ycodetech\valet-windows\cli\valet.php on line 1239

  Also added a deprecation notice for the require statement to prepare for future removal of legacy driver code.

- Added a `use` statement at the top of the file to import the `ValetDriver` namespaced class.