### PR TITLE
Fix fetch-share-url fatal errors and release v3.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/yCodeTech/valet-windows/tree/master)
 
+## [3.4.3](https://github.com/yCodeTech/valet-windows/tree/v3.4.3) - 2026-06-08
+
+### Fixed
+
+- Fixed [#47](https://github.com/yCodeTech/valet-windows/issues/47): `fetch-share-url` command bug that spat out a PHP fatal error when `Valet\retry` helper was undefined; in [#48](https://github.com/yCodeTech/valet-windows/pull/48).
+
+- Fixed bug in `share` command that added the tld on to the specified site even if the site already included the tld. To prevent issues, the command will now remove the tld from the specified site before adding it back in the URL variable.
+
+- Fixed Valet's version, which was still at `3.4.1` in the previous release. Changed it to `3.4.3` to reflect this version.
+
+### Changed
+
+- Improved error messages in the `fetch-share-url` command to be more informative on the site it's trying to fetch the share URL for. This will help debugging.
+
 ## [3.4.2](https://github.com/yCodeTech/valet-windows/tree/v3.4.2) - 2026-06-07
 
 ### Fixed

--- a/cli/Valet/ShareTools/ShareTool.php
+++ b/cli/Valet/ShareTools/ShareTool.php
@@ -72,12 +72,12 @@ abstract class ShareTool {
 	/**
 	 * Get the current tunnel URL from the API.
 	 *
-	 * @param string $site The site
+	 * @param string $site The site that is being shared.
 	 *
 	 * @return string The current tunnel URL
 	 */
 	public function currentTunnelUrl(string $site) {
-		info("Trying to retrieve tunnel URL...");
+		info("Trying to retrieve tunnel URL for '$site'...");
 
 		foreach ($this->tunnelsEndpoints as $endpoint) {
 			try {
@@ -97,7 +97,7 @@ abstract class ShareTool {
 						}
 					}
 
-					throw new DomainException('Failed to retrieve tunnel URL.');
+					throw new DomainException("Failed to retrieve tunnel URL for '$site'.");
 				}, 250);
 
 				// If response is NOT empty, return the response.
@@ -110,13 +110,14 @@ abstract class ShareTool {
 			}
 		}
 
-		throw new DomainException('Tunnel not established.');
+		throw new DomainException("Tunnel not established for '$site'.");
 	}
 
 	/**
 	 * Find the HTTP tunnel URL from the list of tunnels.
 	 *
-	 * @param array $tunnels
+	 * @param array $tunnels The list of tunnels.
+	 * @param string|null $site The site that is being shared.
 	 *
 	 * @return string|null
 	 */

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -179,20 +179,19 @@ function addTableSeparator($rows) {
 	return $separatedRows;
 }
 
-if (!function_exists('resolve')) {
-	/**
-	 * Resolve the given class from the container.
-	 *
-	 * https://laravel.com/docs/12.x/helpers#method-resolve
-	 *
-	 * @param string $class
-	 *
-	 * @return mixed
-	 */
-	function resolve($class) {
-		return Container::getInstance()->make($class);
-	}
+/**
+ * Resolve the given class from the container.
+ *
+ * https://laravel.com/docs/12.x/helpers#method-resolve
+ *
+ * @param string $class
+ *
+ * @return mixed
+ */
+function resolve($class) {
+	return Container::getInstance()->make($class);
 }
+
 
 /**
  * Swap the given class implementation in the container.
@@ -204,56 +203,53 @@ function swap($class, $instance) {
 	Container::getInstance()->instance($class, $instance);
 }
 
-if (!function_exists('retry')) {
-	/**
-	 * Retry the given function N times.
-	 *
-	 * https://laravel.com/docs/12.x/helpers#method-retry
-	 *
-	 * @param int $retries
-	 * @param callable $fn
-	 * @param int $sleep
-	 *
-	 * @return mixed
-	 */
-	function retry($retries, $fn, $sleep = 0) {
-		beginning:
-		try {
-			return $fn();
+/**
+ * Retry the given function N times.
+ *
+ * https://laravel.com/docs/12.x/helpers#method-retry
+ *
+ * @param int $retries
+ * @param callable $fn
+ * @param int $sleep
+ *
+ * @return mixed
+ */
+function retry($retries, $fn, $sleep = 0) {
+	beginning:
+	try {
+		return $fn();
+	}
+	catch (Exception $e) {
+		if (!$retries) {
+			throw $e;
 		}
-		catch (Exception $e) {
-			if (!$retries) {
-				throw $e;
-			}
 
-			$retries--;
+		$retries--;
 
-			if ($sleep > 0) {
-				usleep($sleep * 1000);
-			}
-
-			goto beginning;
+		if ($sleep > 0) {
+			usleep($sleep * 1000);
 		}
+
+		goto beginning;
 	}
 }
 
-if (!function_exists('tap')) {
-	/**
-	 * Tap the given value.
-	 *
-	 * https://laravel.com/docs/12.x/helpers#method-tap
-	 *
-	 * @param mixed $value
-	 * @param callable $callback
-	 *
-	 * @return mixed
-	 */
-	function tap($value, callable $callback) {
-		$callback($value);
+/**
+ * Tap the given value.
+ *
+ * https://laravel.com/docs/12.x/helpers#method-tap
+ *
+ * @param mixed $value
+ * @param callable $callback
+ *
+ * @return mixed
+ */
+function tap($value, callable $callback) {
+	$callback($value);
 
-		return $value;
-	}
+	return $value;
 }
+
 
 /**
  * Get the user.

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -947,7 +947,11 @@ if (is_dir(Valet::homePath()) && Nginx::isInstalled()) {
 			return error("Option shortcuts cannot have a <bg=magenta> = </> immediately after them.\nPlease use a space to separate it from the value: <bg=magenta> valet share $site -o " . preg_replace("/=/", "", $options, 1) . " </>");
 		}
 
-		$url = ($site ?: strtolower(Site::host(getcwd()))) . '.' . Configuration::read()['tld'];
+		$tld = Configuration::read()['tld'];
+		// Remove the tld from the site if it's included, because it'll get added back in the URL variable and this can cause issues if it's included twice.
+		$site = str_replace(".$tld", "", $site);
+
+		$url = ($site ?: strtolower(Site::host(getcwd()))) . '.' . $tld;
 
 		$options = $options != null ? explode("//", $options) : [];
 

--- a/cli/version.php
+++ b/cli/version.php
@@ -3,4 +3,4 @@
 /**
  * @var string $version The version of Laravel Valet Windows.
  */
-$version = '3.4.1';
+$version = '3.4.3';


### PR DESCRIPTION
This pull request addresses several bugs and improvements related to the `share` and `fetch-share-url` commands, as well as maintenance updates for versioning and error handling. The most important changes are summarized below.

Bug fixes:

* Fixed the `fetch-share-url` command to handle cases where the `Valet\retry` helper was undefined, which previously caused a PHP fatal error. 

  > PHP Fatal error:  Uncaught Error: Call to undefined function Valet\retry()...

  This bug was caused when a globally installed composer package defines a `retry` function in the global scope (without namespacing), such as Laravel's helper functions via the Support composer package. But because some of Valet's helpers are wrapped in `function_exists` conditionals, then they only get defined if the function doesn't already exist. So when they does exist in the global scope, Valet can't resolve it because it's helpers are namespaced and therefore it's usage is not global. So when the `ShareTool::currentTunnelUrl` method tried to call Valet's namespaced `retry` helper for the `fetch-share-url` command, the function isn't defined, so PHP errors fatally. Fixed by removing the `function_exists` conditionals so they are always defined.
  Fixes #47.

* Fixed a bug in the `share` command where the TLD was appended even if the site already included it, by stripping the TLD before constructing the URL. This prevents malformed URLs.

* Valet's version was missed from being incremented in the previous release (3.4.2), so Valet would report the wrong version. Updated version from `3.4.1` to `3.4.3` to reflect this release version.

Error handling and messaging improvements:

* Improved error messages in the `fetch-share-url` command to include the site name, making debugging easier. Exceptions and info messages now specify the site involved.