### PR TITLE
fix: ngrok error logging by adding real-time output

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 indent_style = space
-indent_size = 2
+indent_size = 4
 
 [*.yml]
 indent_size = 2

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Also make sure to open your preferred terminal (Windows Terminal, CMD, Git Bash,
 
 ---
 
--   If you don't have PHP installed, make sure to [install](https://windows.php.net/download) it.
+- If you don't have PHP installed, make sure to [install](https://windows.php.net/download) it.
 
     Download the Zip file and unzip into a directory of your choosing. The recommended directory is: `C:/php/`.
 
@@ -211,9 +211,9 @@ Also make sure to open your preferred terminal (Windows Terminal, CMD, Git Bash,
 
     > For NTS binaries the widespread use case is interaction with a web server through the FastCGI protocol, utilizing no multithreading (but also for example CLI).
 
--   If you don't have Composer installed, make sure to [install](https://getcomposer.org/doc/00-intro.md#installation-windows) it.
+- If you don't have Composer installed, make sure to [install](https://getcomposer.org/doc/00-intro.md#installation-windows) it.
 
--   Install Valet with Composer via `composer global require ycodetech/valet-windows`.
+- Install Valet with Composer via `composer global require ycodetech/valet-windows`.
 
     <p align="center"><img src="./art/composer_laravel_valet_windows_3_logo.svg" style="width:400px; background: none;"></p>
 
@@ -221,9 +221,9 @@ Also make sure to open your preferred terminal (Windows Terminal, CMD, Git Bash,
     >
     > **If you're coming from <a href="https://github.com/cretueusebiu/valet-windows">cretueusebiu/valet-windows</a>, then you need to make sure to fully uninstall it from your computer, deleting all configs, and removing from composer with `composer global remove cretueusebiu/valet-windows`, before installing this 3.0 version.**
 
--   Install Valet by running the `valet install` command, or alternatively `valet sudo install` with administrator elevation. This will configure and install Valet and register Valet's daemon to launch when your system starts. Once installed, Valet will automatically start it's services.
+- Install Valet by running the `valet install` command, or alternatively `valet sudo install` with administrator elevation. This will configure and install Valet and register Valet's daemon to launch when your system starts. Once installed, Valet will automatically start it's services.
 
--   If you're installing on Windows 10/11, you may need to [manually configure](https://mayakron.altervista.org/support/acrylic/Windows10Configuration.htm) Windows to use the [Acrylic DNS Proxy](https://mayakron.altervista.org/support/acrylic/Home.htm).
+- If you're installing on Windows 10/11, you may need to [manually configure](https://mayakron.altervista.org/support/acrylic/Windows10Configuration.htm) Windows to use the [Acrylic DNS Proxy](https://mayakron.altervista.org/support/acrylic/Home.htm).
 
 Valet will automatically start its daemon each time your machine boots. There is no need to run `valet start` or `valet install` ever again once the initial Valet installation is complete.
 
@@ -248,11 +248,11 @@ Valet installed and started successfully!
 
 This installs all Valet services:
 
--   Nginx
--   PHP CGI
--   PHP Xdebug CGI [optional]
--   Acrylic DNS
--   Ansicon
+- Nginx
+- PHP CGI
+- PHP Xdebug CGI [optional]
+- Acrylic DNS
+- Ansicon
 
 And it's configs in `C:/Users/Username/.config/valet`.
 
@@ -1462,13 +1462,13 @@ The nginx error pages are `on` (enabled) by default, which means that Valet's cu
 
 These are **important notes** for the commands that have the `--options` or `--valetOptions`.
 
--   The `--options`, `--valetOptions` (shortcut `-o`) options can be used to pass options/flags to the service related to that command.
+- The `--options`, `--valetOptions` (shortcut `-o`) options can be used to pass options/flags to the service related to that command.
 
     Just pass the option name without the `--` prefix eg. `--options=config=C:/path/ngrok.yml` (example for the `ngrok` command). This is so that Valet doesn't get confused with it's own options.
 
     All options/flags that are passed will be prefixed with `--` after Valet has processed the command, unless it's a shortcut of a single character, then it will be prefixed with `-`. The example above will run as `--config=C:/path/ngrok.yml`.
 
--   The `=` immediately after the command option is optional, if it's omitted, you must use a space instead.
+- The `=` immediately after the command option is optional, if it's omitted, you must use a space instead.
 
     ```
     --options=option1
@@ -1477,7 +1477,7 @@ These are **important notes** for the commands that have the `--options` or `--v
     --valetOptions option1
     ```
 
--   The options also have `-o` shortcuts and it cannot have the `=` character, it must use a space for separation.
+- The options also have `-o` shortcuts and it cannot have the `=` character, it must use a space for separation.
 
     ```console
     -o option1
@@ -1489,7 +1489,7 @@ These are **important notes** for the commands that have the `--options` or `--v
 
     > ###### Note that to comply with the docopt standard, long options can specify their values after a whitespace or an `=` sign (e.g. `--iterations 5` or `--iterations=5`), but short options can only use whitespaces or no separation at all (e.g. `-i 5` or `-i5`).
 
--   The options also allows multiple options to be passed, they just need to be separated with double slashes `//`.
+- The options also allows multiple options to be passed, they just need to be separated with double slashes `//`.
 
     ```console
     --valetOptions=option1//option2//option3
@@ -1501,46 +1501,46 @@ These are **important notes** for the commands that have the `--options` or `--v
 
 Commands that have been tested and made parity:
 
--   [ ] composer - not applicable
--   [x] diagnose
--   [x] directory-listing
--   [x] fetch-share-url
--   [x] forget
--   [x] install
--   [x] isolate
--   [x] isolated
--   [x] link
--   [x] links
--   [x] log
--   [ ] loopback (the localhost IP) - not applicable
--   [x] on-latest-version
--   [x] open
--   [x] park
--   [x] parked
--   [x] paths
--   [x] php (proxying commands to PHP CLI) - renamed to `php:proxy` with alias of `php`
--   [x] proxies
--   [x] proxy
--   [ ] renew (Renews all domains with a trusted TLS certificate) - TBD
--   [x] restart
--   [x] secure
--   [x] secured
--   [x] set-ngrok-token
--   [x] share
--   [x] share-tool
--   [x] start
--   [x] status - renamed to `services`
--   [x] stop
--   [x] tld
--   [ ] trust - not applicable
--   [x] uninstall
--   [x] unisolate
--   [x] unlink
--   [x] unproxy
--   [x] unsecure
--   [x] use
--   [x] which
--   [x] which-php - renamed to `php:which`
+- [ ] composer - not applicable
+- [x] diagnose
+- [x] directory-listing
+- [x] fetch-share-url
+- [x] forget
+- [x] install
+- [x] isolate
+- [x] isolated
+- [x] link
+- [x] links
+- [x] log
+- [ ] loopback (the localhost IP) - not applicable
+- [x] on-latest-version
+- [x] open
+- [x] park
+- [x] parked
+- [x] paths
+- [x] php (proxying commands to PHP CLI) - renamed to `php:proxy` with alias of `php`
+- [x] proxies
+- [x] proxy
+- [ ] renew (Renews all domains with a trusted TLS certificate) - TBD
+- [x] restart
+- [x] secure
+- [x] secured
+- [x] set-ngrok-token
+- [x] share
+- [x] share-tool
+- [x] start
+- [x] status - renamed to `services`
+- [x] stop
+- [x] tld
+- [ ] trust - not applicable
+- [x] uninstall
+- [x] unisolate
+- [x] unlink
+- [x] unproxy
+- [x] unsecure
+- [x] use
+- [x] which
+- [x] which-php - renamed to `php:which`
 
 To see a calculation of how much parity has been achieved, see the [parity command](#parity).
 
@@ -1596,56 +1596,56 @@ All services will have been stopped and removed and you can then be able to run 
 
 Upon installation, Valet creates the following directories and config files:
 
--   `~/.config/valet`
-    Contains all of Valet's config files. This resides in the home directory (`C:/Users/Username/`) indicated by `~`.
+- `~/.config/valet`
+  Contains all of Valet's config files. This resides in the home directory (`C:/Users/Username/`) indicated by `~`.
 
--   `~/.config/valet/CA`
-    Contains Valet's generated self-signed Root CA certificate, of which all site TLS certificates are signed with.
+- `~/.config/valet/CA`
+  Contains Valet's generated self-signed Root CA certificate, of which all site TLS certificates are signed with.
 
--   `~/.config/valet/Certificates`
-    Contains all the TLS certificates for the secured sites. These files are rebuilt when running the `install` and `secure` commands.
+- `~/.config/valet/Certificates`
+  Contains all the TLS certificates for the secured sites. These files are rebuilt when running the `install` and `secure` commands.
 
--   `~/.config/valet/Drivers`
-    Contains any user-defined custom Valet drivers. Drivers determine how a particular framework / CMS is served. See the [Valet Docs](https://laravel.com/docs/12.x/valet#custom-valet-drivers) for information on how to create a custom driver.
+- `~/.config/valet/Drivers`
+  Contains any user-defined custom Valet drivers. Drivers determine how a particular framework / CMS is served. See the [Valet Docs](https://laravel.com/docs/12.x/valet#custom-valet-drivers) for information on how to create a custom driver.
 
--   `~/.config/valet/Drivers/SampleValetDriver.php`
-    A sample custom driver.
+- `~/.config/valet/Drivers/SampleValetDriver.php`
+  A sample custom driver.
 
--   `~/.config/valet/Extensions`
-    Contains custom Valet extensions/commands. You can extend Valet and add your own commands or change existing ones. See [this comment](https://github.com/laravel/valet/issues/804#issuecomment-569731561) for more info and links to examples.
+- `~/.config/valet/Extensions`
+  Contains custom Valet extensions/commands. You can extend Valet and add your own commands or change existing ones. See [this comment](https://github.com/laravel/valet/issues/804#issuecomment-569731561) for more info and links to examples.
 
--   `~/.config/valet/Log`
-    Contains all error logs.
+- `~/.config/valet/Log`
+  Contains all error logs.
 
--   `~/.config/valet/Nginx`
-    Contains site-specific Nginx configs for any site that is isolated or secured. These files are rebuilt when running the `install`, `tld`, and `secure` commands.
+- `~/.config/valet/Nginx`
+  Contains site-specific Nginx configs for any site that is isolated or secured. These files are rebuilt when running the `install`, `tld`, and `secure` commands.
 
--   `~/.config/valet/Ngrok`
-    Contains the `ngrok.yml` config file for the ngrok executable to be able to `share` sites. This directory and file will only be created when the `set-ngrok-token` command is run.
+- `~/.config/valet/Ngrok`
+  Contains the `ngrok.yml` config file for the ngrok executable to be able to `share` sites. This directory and file will only be created when the `set-ngrok-token` command is run.
 
--   `~/.config/valet/Services`
-    Contains the Nginx and PHP config and executable files to be able to run them as Windows services. These files are rebuilt when running the `install` command.
+- `~/.config/valet/Services`
+  Contains the Nginx and PHP config and executable files to be able to run them as Windows services. These files are rebuilt when running the `install` command.
 
--   `~/.config/valet/Sites`
-    Contains all of the symbolic links for any `link`ed sites.
+- `~/.config/valet/Sites`
+  Contains all of the symbolic links for any `link`ed sites.
 
--   `~/.config/valet/stubs`
-    A user-created directory to contain custom stubs. Only used in Valet if it exists, and overrides Valet's internal stubs.
+- `~/.config/valet/stubs`
+  A user-created directory to contain custom stubs. Only used in Valet if it exists, and overrides Valet's internal stubs.
 
--   `~/.config/valet/Xdebug`
-    Contains the output files of Xdebug profiling.
+- `~/.config/valet/Xdebug`
+  Contains the output files of Xdebug profiling.
 
--   `~/.config/valet/config.json`
-    This is the main Valet config file.
+- `~/.config/valet/config.json`
+  This is the main Valet config file.
 
--   `~/.config/valet/Emergency Uninstall`
-    Contains the emergency uninstall files.
+- `~/.config/valet/Emergency Uninstall`
+  Contains the emergency uninstall files.
 
--   `~/.config/valet/Emergency Uninstall/ansicon`
-    Contains the Ansicon files and executable to help uninstall it.
+- `~/.config/valet/Emergency Uninstall/ansicon`
+  Contains the Ansicon files and executable to help uninstall it.
 
--   `~/.config/valet/Emergency Uninstall/emergency_uninstall_services.bat`
-    This is an batch file to do an emergency stop and uninstall of all services. See the [Emergency Stop and Uninstall Services section](#emergency-stop-and-uninstall-services).
+- `~/.config/valet/Emergency Uninstall/emergency_uninstall_services.bat`
+  This is an batch file to do an emergency stop and uninstall of all services. See the [Emergency Stop and Uninstall Services section](#emergency-stop-and-uninstall-services).
 
 > [!WARNING]
 >
@@ -1657,12 +1657,12 @@ Upon installation, Valet creates the following directories and config files:
 
 ## Known Issues
 
--   WSL2 distros fail because of Acrylic DNS Proxy ([microsoft/wsl#4929](https://github.com/microsoft/WSL/issues/4929)). Use `valet stop`, start WSL2 then `valet start`.
--   The PHP-CGI process uses port 9001. If it's already used change it in `~/.config/valet/config.json` and run `valet install` again.
--   When sharing sites the url will not be copied to the clipboard.
--   ~~You must run the `valet` commands from the drive where Valet is installed, except for park and link. See [#12](https://github.com/cretueusebiu/valet-windows/issues/12#issuecomment-283111834).~~ All commands seem to work fine on all drives.
--   If your machine is not connected to the internet you'll have to manually add the domains in your `hosts` file or you can install the [Microsoft Loopback Adapter](https://docs.microsoft.com/en-us/troubleshoot/windows-server/networking/install-microsoft-loopback-adapter) as this simulates an active local network interface that Valet can bind too.
--   When trying to run Valet on PHP 7.4 and you get this error:
+- WSL2 distros fail because of Acrylic DNS Proxy ([microsoft/wsl#4929](https://github.com/microsoft/WSL/issues/4929)). Use `valet stop`, start WSL2 then `valet start`.
+- The PHP-CGI process uses port 9001. If it's already used change it in `~/.config/valet/config.json` and run `valet install` again.
+- When sharing sites the url will not be copied to the clipboard.
+- ~~You must run the `valet` commands from the drive where Valet is installed, except for park and link. See [#12](https://github.com/cretueusebiu/valet-windows/issues/12#issuecomment-283111834).~~ All commands seem to work fine on all drives.
+- If your machine is not connected to the internet you'll have to manually add the domains in your `hosts` file or you can install the [Microsoft Loopback Adapter](https://docs.microsoft.com/en-us/troubleshoot/windows-server/networking/install-microsoft-loopback-adapter) as this simulates an active local network interface that Valet can bind too.
+- When trying to run Valet on PHP 7.4 and you get this error:
 
     > Composer detected issues in your platform:
     >
@@ -1684,13 +1684,13 @@ Upon installation, Valet creates the following directories and config files:
     >
     > Make sure you uninstall Valet before `composer global update`, to make sure all services have been stopped and uninstalled before composer removes and updates them. Otherwise errors occur and composer can't update in-use files. If this does happen please refer to the [Emergency Stop and Uninstall Services](#emergency-stop-and-uninstall-services) section.
 
--   If you're using a framework that uses a .env file and sets the domain name, such as `WP_HOME` for Laravel Bedrock, then make sure the TLD is the same as the one set for Valet. Otherwise, when trying to reach a site, the site will auto redirect to use the TLD in set in the .env.
+- If you're using a framework that uses a .env file and sets the domain name, such as `WP_HOME` for Laravel Bedrock, then make sure the TLD is the same as the one set for Valet. Otherwise, when trying to reach a site, the site will auto redirect to use the TLD in set in the .env.
 
     Example: `WP_HOME='http://mySite.test'`, Valet gets a request to `http://mySite.dev`, the site will auto redirect to `http://mySite.test`.
 
     If this still happens after changing the TLD, then it has been cached by the browser, despite NGINX specifying headers not to cache. To rectify try `"Empty cache and hard reload"` option of the page reload button.
 
--   On rare occasions, you may encounter a WMI error:
+- On rare occasions, you may encounter a WMI error:
 
     > FATAL - WMI Operation failure: InvalidServiceControl
     > <br>WMI.WmiException: InvalidServiceControl
@@ -1704,9 +1704,9 @@ Upon installation, Valet creates the following directories and config files:
 
     If the WMI error does occur, try running the command again. If different WMI errors occur, please submit an issue with all relevant details.
 
--   If there is a large error and it's file trace output to the terminal, the top of the error may be cut off/overwritten. Apparently Symfony can only write to the terminal that is viewable, if it goes outside of the viewable area (ie. you need to scroll up to view) then the output is overwritten and the most important part of the error, the description at the start is cut off. (See https://github.com/symfony/symfony/issues/35012). If this happens, make the terminal larger in height and try the command again to try and view the full error.
+- If there is a large error and it's file trace output to the terminal, the top of the error may be cut off/overwritten. Apparently Symfony can only write to the terminal that is viewable, if it goes outside of the viewable area (ie. you need to scroll up to view) then the output is overwritten and the most important part of the error, the description at the start is cut off. (See https://github.com/symfony/symfony/issues/35012). If this happens, make the terminal larger in height and try the command again to try and view the full error.
 
--   When trying to install Valet after updating via Composer, and you receive this error or similiar: `The system cannot find the path specified`; it could be that Ansicon hasn't uninstalled properly and left it's path in the registry. Because it happens unpredictably, there is no way of debugging or fixing it.
+- When trying to install Valet after updating via Composer, and you receive this error or similiar: `The system cannot find the path specified`; it could be that Ansicon hasn't uninstalled properly and left it's path in the registry. Because it happens unpredictably, there is no way of debugging or fixing it.
 
     The only "workaround" is to use the emergency uninstall script (`emergency_uninstall_services.bat`) in the `~/.config/valet/Emergency Uninstall` directory to allow Ansicon another chance to uninstall itself properly. (See [issue 28](https://github.com/yCodeTech/valet-windows/issues/28)). See the [Emergency Stop and Uninstall Services section](#emergency-stop-and-uninstall-services).
 

--- a/README.md
+++ b/README.md
@@ -1108,7 +1108,15 @@ Before sharing a site with ngrok, you must first set the authtoken using Valet's
 
 > [!NOTE]
 >
-> The public URL won't be displayed, however, in a separate terminal, you can use the [`fetch-share-url` command](#fetch-share-url) to get the url and copy it to the clipboard.
+> Prior to v3.4.4, the public URL wasn't displayed and the [`fetch-share-url` command](#fetch-share-url) had to be used instead to get the URL and copy it to the clipboard.
+>
+> As of v3.4.4, the public URL **will** be displayed and automatically copied to your clipboard (requires ngrok's real-time logging). You can still use the `fetch-share-url` command in a separate terminal though.
+
+> [!IMPORTANT]
+>
+> ngrok will now output logging information directly to the terminal in real-time by default using the `--log=stdout` option. Valet redirects stderr to stdout, so all logging information will be outputted to the terminal. This is useful for debugging and seeing what ngrok is doing in real-time. For this reason the `--log=stderr` is exactly the same output as `--log=stdout`.
+>
+> If you wish to disable real-time logging, you can use the valet's `--options` argument to pass ngrok's `log=false` option; this will disable all logging output to the terminal, including the public URL.
 
 ###### share --options
 

--- a/README.md
+++ b/README.md
@@ -1659,7 +1659,7 @@ Upon installation, Valet creates the following directories and config files:
 
 - WSL2 distros fail because of Acrylic DNS Proxy ([microsoft/wsl#4929](https://github.com/microsoft/WSL/issues/4929)). Use `valet stop`, start WSL2 then `valet start`.
 - The PHP-CGI process uses port 9001. If it's already used change it in `~/.config/valet/config.json` and run `valet install` again.
-- When sharing sites the url will not be copied to the clipboard.
+- ~~When sharing sites the url will not be copied to the clipboard.~~ The URL will now be copied to the clipboard automatically as of v3.4.4; see the [share command](#share) for more information.
 - ~~You must run the `valet` commands from the drive where Valet is installed, except for park and link. See [#12](https://github.com/cretueusebiu/valet-windows/issues/12#issuecomment-283111834).~~ All commands seem to work fine on all drives.
 - If your machine is not connected to the internet you'll have to manually add the domains in your `hosts` file or you can install the [Microsoft Loopback Adapter](https://docs.microsoft.com/en-us/troubleshoot/windows-server/networking/install-microsoft-loopback-adapter) as this simulates an active local network interface that Valet can bind too.
 - When trying to run Valet on PHP 7.4 and you get this error:

--- a/cli/Valet/CommandLine.php
+++ b/cli/Valet/CommandLine.php
@@ -48,6 +48,9 @@ class CommandLine {
 		// Open a process to execute the command and read its output.
 		// 2>&1 redirects stderr to stdout so we can capture both.
 		$handle = popen("$command 2>&1", 'r');
+		if ($handle === false) {
+			error('Failed to start command for streaming output.', true);
+		}
 		while ($handle && !feof($handle)) {
 			$line = fgets($handle);
 			if ($line === false) {

--- a/cli/Valet/CommandLine.php
+++ b/cli/Valet/CommandLine.php
@@ -48,9 +48,12 @@ class CommandLine {
 		// Open a process to execute the command and read its output.
 		// 2>&1 redirects stderr to stdout so we can capture both.
 		$handle = popen("$command 2>&1", 'r');
+
+		// If the process failed to start, throw an error.
 		if ($handle === false) {
 			error('Failed to start command for streaming output.', true);
 		}
+
 		while ($handle && !feof($handle)) {
 			$line = fgets($handle);
 			if ($line === false) {

--- a/cli/Valet/CommandLine.php
+++ b/cli/Valet/CommandLine.php
@@ -31,16 +31,17 @@ class CommandLine {
 	 * Stream command output in real time and optionally collect matching lines.
 	 *
 	 * @param string $command
-	 * @param callable|null $lineMatches Callback to check matching lines; must return `true`
-	 * to collect the line for post-run analysis.
-	 * @param callable|null $lineIsError Callback to check whether a line should be
-	 * rendered as an error in real time. If omitted, the capture matcher is reused.
+	 * @param array $callbacks Optional callbacks:
+	 * - matches (callable): return true to collect line for post-run analysis.
+	 * - isError (callable): return true to render line as an error. Defaults to matches.
 	 *
 	 * @return array The collected output lines or an empty array if no lines were collected.
 	 */
-	public function streamCommandOutput($command, ?callable $lineMatches = null, ?callable $lineIsError = null): array {
+	public function streamCommandOutput($command, array $callbacks = []): array {
+		$lineMatches = $callbacks['matches'] ?? null;
+		$lineIsError = $callbacks['isError'] ?? $lineMatches;
+
 		$capturedLines = [];
-		$lineIsError = $lineIsError ?: $lineMatches;
 
 		// Open a process to execute the command and read its output.
 		$handle = popen("$command 2>&1", 'r');

--- a/cli/Valet/CommandLine.php
+++ b/cli/Valet/CommandLine.php
@@ -28,6 +28,52 @@ class CommandLine {
 	}
 
 	/**
+	 * Stream command output in real time and optionally collect matching lines.
+	 *
+	 * @param string $command
+	 * @param callable|null $lineMatches Callback to check matching lines; must return `true`
+	 * to collect the line for post-run analysis.
+	 * @param callable|null $lineIsError Callback to check whether a line should be
+	 * rendered as an error in real time. If omitted, the capture matcher is reused.
+	 *
+	 * @return array The collected output lines or an empty array if no lines were collected.
+	 */
+	public function streamCommandOutput($command, ?callable $lineMatches = null, ?callable $lineIsError = null): array {
+		$capturedLines = [];
+		$lineIsError = $lineIsError ?: $lineMatches;
+
+		// Open a process to execute the command and read its output.
+		$handle = popen("$command 2>&1", 'r');
+		while ($handle && !feof($handle)) {
+			$line = fgets($handle);
+			if ($line === false) {
+				break;
+			}
+
+			// Keep raw command output unless caller explicitly marks this line as an error.
+			if ($lineIsError && $lineIsError($line)) {
+				error($line, false, false, true);
+			}
+			else {
+				echo $line;
+			}
+
+			// If a callback is provided and the line matches the condition,
+			// then collect the line for post-run analysis.
+			if ($lineMatches && $lineMatches($line)) {
+				$capturedLines[] = trim($line);
+			}
+		}
+
+		// Close the process.
+		if ($handle) {
+			pclose($handle);
+		}
+
+		return $capturedLines;
+	}
+
+	/**
 	 * Pass the given Valet command to the command line with elevated privileges using gsudo.
 	 *
 	 * gsudo is a sudo equivalent of the Mac `sudo` utility. It allows the user to run commands as the root user with elevated privileges with minimal amount of UAC popups, ie. only 1 UAC popup.

--- a/cli/Valet/CommandLine.php
+++ b/cli/Valet/CommandLine.php
@@ -54,12 +54,13 @@ class CommandLine {
 				break;
 			}
 
-			// Keep raw command output unless caller explicitly marks this line as an error.
+			// If the line is an error, output it as an error.
 			if ($lineIsError && $lineIsError($line)) {
 				error($line, false, false, true);
 			}
+			// Otherwise, output it normally.
 			else {
-				echo $line;
+				output($line, false);
 			}
 
 			// Invoke the optional line handler after writing output so callers can append

--- a/cli/Valet/CommandLine.php
+++ b/cli/Valet/CommandLine.php
@@ -32,18 +32,21 @@ class CommandLine {
 	 *
 	 * @param string $command
 	 * @param array $callbacks Optional callbacks:
+	 * - onLine (callable): receives every raw line after it is written.
 	 * - matches (callable): return true to collect line for post-run analysis.
 	 * - isError (callable): return true to render line as an error. Defaults to matches.
 	 *
 	 * @return array The collected output lines or an empty array if no lines were collected.
 	 */
 	public function streamCommandOutput($command, array $callbacks = []): array {
+		$lineHandler = $callbacks['onLine'] ?? null;
 		$lineMatches = $callbacks['matches'] ?? null;
 		$lineIsError = $callbacks['isError'] ?? $lineMatches;
 
 		$capturedLines = [];
 
 		// Open a process to execute the command and read its output.
+		// 2>&1 redirects stderr to stdout so we can capture both.
 		$handle = popen("$command 2>&1", 'r');
 		while ($handle && !feof($handle)) {
 			$line = fgets($handle);
@@ -57,6 +60,12 @@ class CommandLine {
 			}
 			else {
 				echo $line;
+			}
+
+			// Invoke the optional line handler after writing output so callers can append
+			// follow-up messages in display order.
+			if ($lineHandler) {
+				$lineHandler($line);
 			}
 
 			// If a callback is provided and the line matches the condition,

--- a/cli/Valet/ShareTools/Ngrok.php
+++ b/cli/Valet/ShareTools/Ngrok.php
@@ -26,20 +26,31 @@ class Ngrok extends ShareTool {
 			exit(1);
 		}
 
-		// If host-header is not specified,
-		// then set it into the array with a default value of rewrite.
-		if (!stripos(json_encode($options), 'host-header')) {
-			array_push($options, "host-header=rewrite");
+		// Apply defaults for various options the user has not already specified.
+		$defaults = [
+			'host-header' => 'rewrite',
+			// Logging options: log to stdout at info level, enables real-time output
+			// and post-run error analysis.
+			// Logging options are undocumented for the http command, but is defined as
+			// API flags but still works for the http command. See ngrok docs for more details:
+			// https://ngrok.com/docs/agent/cli-api#flags-2
+			'log'         => 'stdout',
+			'log-level'   => 'info',
+			'log-format'  => 'term'
+		];
+
+		// Merge defaults with user-specified options, giving precedence to user-specified options.
+		foreach ($defaults as $key => $value) {
+			if (!array_filter($options, fn($opt) => strpos($opt, "$key=") === 0)) {
+				$options[] = "$key=$value";
+			}
 		}
 
 		$options = prefixOptions($options);
 
 		$ngrok = realpath(valetBinPath() . 'ngrok.exe');
 
-		// Log to stdout, log level info, and log format term for real-time output.
-		$logging = "--log=stdout --log-level=info --log-format=term";
-
-		$ngrokCommand = "\"$ngrok\" http $site:$port " . $this->getConfig() . " $options $logging";
+		$ngrokCommand = "\"$ngrok\" http $site:$port " . $this->getConfig() . " $options";
 
 		info("Sharing $site...\n");
 		info("To output the public URL, please open a new terminal and run `valet fetch-share-url $site`");

--- a/cli/Valet/ShareTools/Ngrok.php
+++ b/cli/Valet/ShareTools/Ngrok.php
@@ -22,9 +22,7 @@ class Ngrok extends ShareTool {
 	 */
 	public function start(string $site, int $port, array $options = []) {
 		if ($port === 443 && !$this->hasAuthToken()) {
-			output('Forwarding to local port 443 or a local https:// URL is only available after you sign up.
-Sign up at: <fg=blue>https://ngrok.com/signup</>
-Then use: <fg=magenta>valet set-ngrok-token [token]</>');
+			output("Forwarding to local port 443 or a local https:// URL is only available after you sign up.\nSign up at: <fg=blue>https://ngrok.com/signup</>\nThen use: <fg=magenta>valet set-ngrok-token [token]</>");
 			exit(1);
 		}
 

--- a/cli/Valet/ShareTools/Ngrok.php
+++ b/cli/Valet/ShareTools/Ngrok.php
@@ -85,6 +85,9 @@ class Ngrok extends ShareTool {
 				$didOutputShareUrl = true;
 				// Output an info message with extracted public URL.
 				info("The public URL for $site is: <fg=blue>$matches[1]</>");
+
+				// Copy the public URL to the clipboard for ease.
+				$this->copyUrlToClipboard($matches[1]);
 			}
 		};
 

--- a/cli/Valet/ShareTools/Ngrok.php
+++ b/cli/Valet/ShareTools/Ngrok.php
@@ -50,9 +50,10 @@ class Ngrok extends ShareTool {
 			return strpos($line, 'ERROR:') !== false;
 		};
 
-		// Pass the same matcher once; CommandLine reuses it for error styling when no separate
-		// error callback is supplied.
-		$errorLines = $this->cli->streamCommandOutput($ngrokCommand, $isErrorLine);
+		// Stream ngrok output in real time and collect error lines for post-run analysis.
+		$errorLines = $this->cli->streamCommandOutput($ngrokCommand, [
+			'matches' => $isErrorLine
+		]);
 
 		if (!empty($errorLines) && strpos(implode("\n", $errorLines), 'ERR_NGROK_121') !== false) {
 			info("\nTo update ngrok yourself, please run `valet ngrok update` and then upgrade the config file by running `valet ngrok config upgrade`\n");

--- a/cli/Valet/ShareTools/Ngrok.php
+++ b/cli/Valet/ShareTools/Ngrok.php
@@ -66,7 +66,7 @@ class Ngrok extends ShareTool {
 		// Stream ngrok output in real time and collect error lines for post-run analysis.
 		// Shared matcher: use the same rule for live error styling and for post-run capture.
 		$isErrorLine = function ($line) {
-			return strpos($line, 'ERROR:') !== false;
+			return strpos($line, 'ERROR:') !== false || strpos($line, 'ERR_NGROK_') !== false;
 		};
 
 		$didOutputShareUrl = false;

--- a/cli/Valet/ShareTools/Ngrok.php
+++ b/cli/Valet/ShareTools/Ngrok.php
@@ -38,19 +38,26 @@ Then use: <fg=magenta>valet set-ngrok-token [token]</>');
 
 		$ngrok = realpath(valetBinPath() . 'ngrok.exe');
 
-		$ngrokCommand = "\"$ngrok\" http $site:$port " . $this->getConfig() . " $options";
+		// Log to stdout, log level info, and log format term for real-time output.
+		$logging = "--log=stdout --log-level=info --log-format=term";
+
+		$ngrokCommand = "\"$ngrok\" http $site:$port " . $this->getConfig() . " $options $logging";
 
 		info("Sharing $site...\n");
 		info("To output the public URL, please open a new terminal and run `valet fetch-share-url $site`");
 
-		$output = $this->cli->shellExec("$ngrokCommand 2>&1");
+		// Stream ngrok output in real time and collect error lines for post-run analysis.
+		// Shared matcher: use the same rule for live error styling and for post-run capture.
+		$isErrorLine = function ($line) {
+			return strpos($line, 'ERROR:') !== false;
+		};
 
-		if ($errors = strstr($output, "ERROR")) {
-			error($errors . PHP_EOL);
+		// Pass the same matcher once; CommandLine reuses it for error styling when no separate
+		// error callback is supplied.
+		$errorLines = $this->cli->streamCommandOutput($ngrokCommand, $isErrorLine);
 
-			if (strpos($errors, 'ERR_NGROK_121') !== false) {
-				info("To update ngrok yourself, please run `valet ngrok update` and then upgrade the config file by running `valet ngrok config upgrade`\n");
-			}
+		if (!empty($errorLines) && strpos(implode("\n", $errorLines), 'ERR_NGROK_121') !== false) {
+			info("\nTo update ngrok yourself, please run `valet ngrok update` and then upgrade the config file by running `valet ngrok config upgrade`\n");
 		}
 	}
 

--- a/cli/Valet/ShareTools/Ngrok.php
+++ b/cli/Valet/ShareTools/Ngrok.php
@@ -34,6 +34,9 @@ class Ngrok extends ShareTool {
 			// Logging options are undocumented for the http command, but is defined as
 			// API flags but still works for the http command. See ngrok docs for more details:
 			// https://ngrok.com/docs/agent/cli-api#flags-2
+			//
+			// (Note: Both `stdout` and `stderr` values capture the same output since
+			// `CommandLine::streamCommandOutput` method uses `2>&1` to redirect stderr to stdout.)
 			'log'         => 'stdout',
 			'log-level'   => 'info',
 			'log-format'  => 'term'
@@ -53,7 +56,12 @@ class Ngrok extends ShareTool {
 		$ngrokCommand = "\"$ngrok\" http $site:$port " . $this->getConfig() . " $options";
 
 		info("Sharing $site...\n");
-		info("To output the public URL, please open a new terminal and run `valet fetch-share-url $site`");
+
+		// If the options string doesn't contain the `--log` option with values of either `stdout`
+		// or `stderr`,then inform the user that they can fetch the public URL in a new terminal.
+		if (strpos($options, '--log=stdout') === false && strpos($options, '--log=stderr') === false) {
+			info("To output the public URL, please open a new terminal and run `valet fetch-share-url $site`");
+		}
 
 		// Stream ngrok output in real time and collect error lines for post-run analysis.
 		// Shared matcher: use the same rule for live error styling and for post-run capture.
@@ -61,8 +69,28 @@ class Ngrok extends ShareTool {
 			return strpos($line, 'ERROR:') !== false;
 		};
 
+		$didOutputShareUrl = false;
+
+		// Line handler: check each line for the "started tunnel" log line to find and
+		// extract the public URL.
+		$lineHandler = function ($line) use ($site, &$didOutputShareUrl) {
+			// If the share URL has already been output, skip further processing.
+			if ($didOutputShareUrl) {
+				return;
+			}
+
+			// If the line contains the 'msg="started tunnel"' message AND has a 'url=' key...
+			if (strpos($line, 'msg="started tunnel"') !== false && preg_match('/\burl=(\S+)/', $line, $matches)) {
+				// Set the flag to true to avoid further processing of lines.
+				$didOutputShareUrl = true;
+				// Output an info message with extracted public URL.
+				info("The public URL for $site is: <fg=blue>$matches[1]</>");
+			}
+		};
+
 		// Stream ngrok output in real time and collect error lines for post-run analysis.
 		$errorLines = $this->cli->streamCommandOutput($ngrokCommand, [
+			'onLine' => $lineHandler,
 			'matches' => $isErrorLine
 		]);
 

--- a/cli/Valet/ShareTools/ShareTool.php
+++ b/cli/Valet/ShareTools/ShareTool.php
@@ -90,8 +90,7 @@ abstract class ShareTool {
 					if (isset($body->tunnels) && count($body->tunnels) > 0) {
 						// If the tunnel URL is NOT null, return the URL.
 						if ($tunnelUrl = $this->findHttpTunnelUrl($body->tunnels, $site)) {
-							// Use | clip to copy the URL to the clipboard.
-							$this->cli->passthru("echo $tunnelUrl | clip");
+							$this->copyUrlToClipboard($tunnelUrl);
 
 							return $tunnelUrl;
 						}
@@ -131,5 +130,15 @@ abstract class ShareTool {
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Copy the public URL to the clipboard.
+	 *
+	 * @param string $url The public URL to copy.
+	 */
+	public function copyUrlToClipboard(string $url) {
+		$this->cli->passthru("echo $url | clip");
+		info("It has been copied to your clipboard.");
 	}
 }

--- a/cli/Valet/ShareTools/ShareTool.php
+++ b/cli/Valet/ShareTools/ShareTool.php
@@ -138,7 +138,12 @@ abstract class ShareTool {
 	 * @param string $url The public URL to copy.
 	 */
 	public function copyUrlToClipboard(string $url) {
-		$this->cli->passthru("echo $url | clip");
+		// Escape single quotes in the URL for PowerShell.
+		$escapedUrl = str_replace("'", "''", $url);
+		// The single quotes around the URL are necessary to ensure that PowerShell treats it as
+		// a literal string, even if it contains spaces or special shell characters and prevents
+		// command injection.
+		$this->cli->powershell("'{$escapedUrl}' | Set-Clipboard");
 		info("It has been copied to your clipboard.");
 	}
 }

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 
 if (!isset($_SERVER['HOME'])) {
 	$_SERVER['HOME'] = $_SERVER['USERPROFILE'];
@@ -62,11 +63,16 @@ function warning($output) {
  *
  * @param string $output
  * @param bool $exception Optionally pass a boolean to indicate whether to throw an exception. If `true`, the error will be thrown as a `ValetException`. [default: `false`]
+ * @param bool $newline Whether to append a newline after the error output. [default: `true`]
+ * @param bool $escapeOutput Whether to escape the output to prevent formatting issues. [default: `false`]
  *
  * @throws RuntimeException
  * @throws ValetException
  */
-function error(string $output, $exception = false) {
+function error(string $output, bool $exception = false, bool $newline = true, bool $escapeOutput = false) {
+
+	$errorOutput = (new ConsoleOutput())->getErrorOutput();
+
 	if (isset($_ENV['APP_ENV']) && $_ENV['APP_ENV'] === 'testing') {
 		throw new RuntimeException($output);
 	}
@@ -78,12 +84,17 @@ function error(string $output, $exception = false) {
 		usleep(1);
 
 		// Print the error message to the console.
-		(new ConsoleOutput())->getErrorOutput()->writeln("\n\n<error>$errors</error>");
+		$errorOutput->write("\n\n<error>$errors</error>", $newline);
 
 		exit();
 	}
 	else {
-		(new ConsoleOutput())->getErrorOutput()->writeln("<error>$output</error>");
+		// If escapeOutput is true, then escape the output to prevent any formatting issues.
+		if ($escapeOutput) {
+			$output = OutputFormatter::escape($output);
+		}
+
+		$errorOutput->write("<error>$output</error>", $newline);
 	}
 }
 

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -102,12 +102,13 @@ function error(string $output, bool $exception = false, bool $newline = true, bo
  * Output the given text to the console.
  *
  * @param string $output
+ * @param bool $newline Whether to append a newline after the output. [default: `true`]
  */
-function output($output) {
+function output($output, bool $newline = true) {
 	if (isset($_ENV['APP_ENV']) && $_ENV['APP_ENV'] === 'testing') {
 		return;
 	}
-	(new ConsoleOutput())->writeln($output);
+	(new ConsoleOutput())->write($output, $newline);
 }
 
 /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -978,7 +978,6 @@ if (is_dir(Valet::homePath()) && Nginx::isInstalled()) {
 
 		$url = Share::shareTool()->currentTunnelUrl($site);
 		info("The public URL for $site is: <fg=blue>$url</>");
-		info("It has been copied to your clipboard.");
 
 	})->setAliases(["url"])->descriptions('Get and copy the public URL of the current working directory site that is currently being shared', [
 		"site" => "Optionally, specify a site"


### PR DESCRIPTION
Technically a follow-up to issue #48 that prompted me to double check ngrok was running properly; and also a follow-up and enhancement of commit 2724314

It was really hard to figure out if there was something wrong with ngrok without proper logging. Ngrok does actually have an undocumented `--log` option for the `http` command (but documented as [API flags](https://ngrok.com/docs/agent/cli-api#flags-2)), so we can use this to stream live logging output directly to the terminal.

### Summary

This pull request introduces significant improvements to the ngrok sharing experience in Valet, including real-time logging, automatic copying of the public URL to the clipboard, and a more robust streaming of ngrok output. It also updates documentation to reflect these changes and includes some minor codebase improvements.

**Enhancements to ngrok sharing and output handling:**

* Added a new `streamCommandOutput` method in `CommandLine.php` to stream command output in real-time, with support for error detection, line handling, and formatting errors as valet errors.
* Updated `Ngrok.php` to:
  - Set default ngrok options for real-time logging (`log=stdout`, `log-level=info`, `log-format=term`), with ability for users to override these settings or completely disable the real-time logging.
  - Stream ngrok output in real-time, detect and display the public URL when available (formatted as an information output), and copy it to the clipboard automatically.
  - Inform the user how to fetch the public URL if real-time logging is disabled.

**Clipboard improvements:**

* Refactored URL copying logic into a reusable `copyUrlToClipboard` method in `ShareTool.php`, ensuring consistent and secure clipboard operations.
* Removed redundant clipboard message in `valet.php` since the new method handles user notification.

**Error and output handling:**

* Enhanced the `error` and `output` helper functions to improve formatting and robustness.
  - Changing the usage of Symfony's `writeln` to `write` to support optional writing of newlines at the end of the output.
  - Included the Symfony `OutputFormatter` for output escaping in the `error` helper function.
